### PR TITLE
refactor(utility): make "NameMixin.dumps()" private

### DIFF
--- a/tensorbay/dataset/segment.py
+++ b/tensorbay/dataset/segment.py
@@ -95,7 +95,7 @@ class Segment(NameMixin, UserMutableSequence["DataBase._Type"]):
             A dict contains the name and the data of the segment.
 
         """
-        contents: Dict[str, Any] = super().dumps()
+        contents: Dict[str, Any] = super()._dumps()
         contents["data"] = [data.dumps() for data in self._data]
 
         return contents
@@ -211,7 +211,7 @@ class FusionSegment(NameMixin, UserMutableSequence[Frame]):
             A dictonary contains the name, the sensors and the frames of the fusion segment.
 
         """
-        contents: Dict[str, Any] = super().dumps()
+        contents: Dict[str, Any] = super()._dumps()
         contents["sensors"] = [sensor.dumps() for sensor in self.sensors.values()]
         contents["frames"] = [frame.dumps() for frame in self._data]
 

--- a/tensorbay/label/attributes.py
+++ b/tensorbay/label/attributes.py
@@ -309,7 +309,7 @@ class AttributeInfo(NameMixin, Items):
             A dict containing all the information of this attribute.
 
         """
-        contents: Dict[str, Any] = NameMixin.dumps(self)
+        contents: Dict[str, Any] = NameMixin._dumps(self)
         contents.update(Items.dumps(self))
 
         if hasattr(self, "parent_categories"):

--- a/tensorbay/label/supports.py
+++ b/tensorbay/label/supports.py
@@ -65,6 +65,21 @@ class CategoryInfo(NameMixin):
         """
         return common_loads(cls, contents)
 
+    def dumps(self) -> Dict[str, str]:
+        """Dumps the CatagoryInfo into a dict.
+
+        Returns:
+            A dict containing the information in the CategoryInfo,
+            whose format is like::
+
+                {
+                    "name": <str>
+                    "description": <str>
+                }
+
+        """
+        return super()._dumps()
+
 
 class _VisibleType(Enum):
     """All the possible visible types of keypoints labels."""
@@ -216,7 +231,6 @@ class KeypointsInfo(ReprMixin):
                     "parentCategories": [...],
                     "description":
                 }
-
 
         """
         contents: Dict[str, Any] = {"number": self._number}

--- a/tensorbay/sensor/sensor.py
+++ b/tensorbay/sensor/sensor.py
@@ -125,7 +125,7 @@ class Sensor(NameMixin, TypeMixin[SensorType]):
             A dict containing the information of the sensor.
 
         """
-        contents: Dict[str, Any] = super().dumps()
+        contents: Dict[str, Any] = super()._dumps()
         contents["type"] = self.enum.value
         if hasattr(self, "extrinsics"):
             contents["extrinsics"] = self.extrinsics.dumps()

--- a/tensorbay/utility/name.py
+++ b/tensorbay/utility/name.py
@@ -54,6 +54,25 @@ class NameMixin(ReprMixin):
         if "description" in contents:
             self.description = contents["description"]
 
+    def _dumps(self) -> Dict[str, str]:
+        """Dumps the instance into a dict.
+
+        Returns:
+            A dict containing the name and the description,
+            whose format is like::
+
+                {
+                    "name": <str>
+                    "description": <str>
+                }
+
+        """
+        contents = {"name": self._name}
+        if self.description:
+            contents["description"] = self.description
+
+        return contents
+
     @classmethod
     def loads(cls: Type[_P], contents: Dict[str, str]) -> _P:
         """Loads a NameMixin from a dict containing the information of the NameMixin.
@@ -81,19 +100,6 @@ class NameMixin(ReprMixin):
 
         """
         return self._name
-
-    def dumps(self) -> Dict[str, str]:
-        """Dumps the instance into a dict.
-
-        Returns:
-            A dict containing the name and the description.
-
-        """
-        contents = {"name": self._name}
-        if self.description:
-            contents["description"] = self.description
-
-        return contents
 
 
 _T = TypeVar("_T", bound=NameMixin)


### PR DESCRIPTION
The class "Dataset" is the subclass of NameMixin, but "Dataset" does not
support "dumps" methods yet. Make "NameMixin.dumps()" private to make
sure "dumps" can not be called from "Dataset"
