### PR TITLE
docs: refine the titles, contents and comments of 5 chapters

### DIFF
--- a/docs/source/api_reference.rst
+++ b/docs/source/api_reference.rst
@@ -1,8 +1,8 @@
-tensorbaySDK API
-================
+API Reference
+=============
 
 .. toctree::
-   :maxdepth: 4
+   :maxdepth: 1
 
    api/client/client_module
    api/dataset/dataset_module

--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -2,9 +2,12 @@
  Examples
 ##########
 
+We write an example for each
+:ref:`supported label types <supported_label_types:Supported Label Types>`.
+Click following links for details.
+
 .. toctree::
-   :maxdepth: 2
-   :caption: Contents
+   :maxdepth: 1
 
    examples/image-classification
    examples/image-box2d

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,18 +1,3 @@
-..
-   TensorBay documentation master file, created by
-   sphinx-quickstart on Thu Dec 31 13:46:01 2020.
-   You can adapt this file completely to your liking, but it should at least
-   contain the root `toctree` directive.
-
-..
-   Welcome to TensorBay's documentation!
-
-..
-   Hello, TensorBay!
-
-..
-   =====================================
-
 ####################
  What is TensorBay?
 ####################
@@ -21,7 +6,7 @@ As an expert in unstructured data management, `TensorBay`_ provides services lik
 complex data version management, online data visualization, and data collaboration.
 TensorBay's unified authority management makes your data sharing and collaborative use more secure.
 This documentation describes :ref:`SDK <quick_start:Quick Start>` and
-:ref:`CLI <features/tensor_cli:Tensorbay CLI>` tools for using TensorBay.
+:ref:`CLI <features/tensorbay_cli:Tensorbay CLI>` tools for using TensorBay.
 
 .. _TensorBay: https://www.graviti.cn/
 
@@ -30,26 +15,20 @@ This documentation describes :ref:`SDK <quick_start:Quick Start>` and
  What can TensorBay SDK do? 
 ############################
 
-.. #image:: images/read_pipeline.png
-
 TensorBay SDK supports methods to:
 
-- :ref:`create dataset from local <quick_start:Create Dataset from Local>`
-- :ref:`upload dataset to TensorBay <quick_start:Upload Local Dataset to TensorBay>`
-- :ref:`read dataset from TensorBay <quick_start:Read Dataset from TensorBay>`
+- :ref:`create local dataset <quick_start:Create Local Dataset>`
+- :ref:`upload local dataset to TensorBay <quick_start:Upload Local Dataset`
+- :ref:`read dataset from TensorBay <quick_start:Read TensorBay Dataset`
 - :ref:`manage dataset versions <features/version_control:Version Control>`
-
-.. ############################
-..  What can TensorBay CLI do? 
-.. ############################
 
 You can also use TensorBay CLI to operate your datasets.
 See :ref:`this page <features/tensorbay_cli:TensorBay CLI>` for more details.
 
 
-##########
- Contents
-##########
+#######
+ Index
+#######
 
 .. toctree::
    :maxdepth: 2
@@ -59,7 +38,7 @@ See :ref:`this page <features/tensorbay_cli:TensorBay CLI>` for more details.
    supported_label_types
    features
    examples
-   tensorbay_sdk_api
+   api_reference
 
 ..
    advanced_features
@@ -67,17 +46,3 @@ See :ref:`this page <features/tensorbay_cli:TensorBay CLI>` for more details.
    contribution
 ..
    exception
-..
-   Indices and tables
-
-..
-   ==================
-
-..
-   * :ref:`genindex`
-
-..
-   * :ref:`modindex`
-
-..
-   * :ref:`search`

--- a/docs/source/quick_start.rst
+++ b/docs/source/quick_start.rst
@@ -45,7 +45,8 @@ Please visit `Graviti AI Service(GAS)`_ to sign up.
 An AccessKey is needed to authenticate identity on TensorBay via SDK or CLI.
 See `this page <https://gas.graviti.cn/access-key>`_ for how to get an AccessKey.
 
-To authenticate identity via SDK, initialize a ``GAS`` client by AccessKey:
+To authenticate identity via SDK, initialize a ``GAS`` (:ref:`features/tensorbay_client:GAS Client`)
+client by AccessKey:
 
 .. code:: python
 

--- a/docs/source/supported_label_types.rst
+++ b/docs/source/supported_label_types.rst
@@ -5,9 +5,9 @@
 TensorBay supports multiple types of labels.
 
 Each :class:`~tensorbay.dataset.data.Data` object
-can have multiple types of :class:.label<tensorbay.dataset.data.Label>`.
+can have multiple types of :class:`label <tensorbay.dataset.data.Label>`.
 
-And each type of :class:.label<tensorbay.dataset.data.Label>` is supported with a specific label
+And each type of :class:`label <tensorbay.dataset.data.Label>` is supported with a specific label
 class,
 and has a corresponding :ref:`subcatalog<basic_concepts:Catalog & Subcatalog>` class.
 


### PR DESCRIPTION
changed files:
- tensorbay_sdk_api -> api_reference
    - change file name
    - change title
- examples
    - change content
- index
    - change content
    - change title
    - remove redundant comment
- quick_start
    - change content
- supported_label_types
    - change content