### PR TITLE
refactor: use matrix as keyword arg to init Transfrom3D and CameraMatrix

### DIFF
--- a/docs/source/reference/label_format.rst
+++ b/docs/source/reference/label_format.rst
@@ -401,18 +401,18 @@ To create a :class:`~tensorbay.label.label_box.LabeledBox3D` label:
 
     >>> from tensorbay.label import LabeledBox3D
     >>> box3d_label = LabeledBox3D(
+    ... size=[10, 20, 30],
     ... translation=[0, 0, 0],
     ... rotation=[1, 0, 0, 0],
-    ... size=[10, 20, 30],
     ... category="category",
     ... attributes={"attribute_name": "attribute_value"},
     ... instance="instance_ID"
     ... )
     >>> box3d_label
     LabeledBox3D(
+      (size): Vector3D(10, 20, 30),
       (translation): Vector3D(0, 0, 0),
       (rotation): quaternion(1.0, 0.0, 0.0, 0.0),
-      (size): Vector3D(10, 20, 30),
       (category): 'category',
       (attributes): {...},
       (instance): 'instance_ID'
@@ -430,23 +430,23 @@ you can use the transform matrix and the size of the 3D bounding box,
 or you can use translation and rotation to represent the transform of the 3D bounding box.
 
     >>> LabeledBox3D(
-    ... [[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]],
     ... size=[10, 20, 30],
+    ... transform_matrix=[[1, 0, 0, 0], [0, 1, 0, 0], [0, 0, 1, 0]],
     ... )
     LabeledBox3D(
+      (size): Vector3D(10, 20, 30)
       (translation): Vector3D(0, 0, 0),
       (rotation): quaternion(1.0, -0.0, -0.0, -0.0),
-      (size): Vector3D(10, 20, 30)
     )
     >>> LabeledBox3D(
+    ... size=[10, 20, 30],
     ... translation=[0, 0, 0],
     ... rotation=[1, 0, 0, 0],
-    ... size=[10, 20, 30],
     ... )
     LabeledBox3D(
+      (size): Vector3D(10, 20, 30)
       (translation): Vector3D(0, 0, 0),
       (rotation): quaternion(1.0, 0.0, 0.0, 0.0),
-      (size): Vector3D(10, 20, 30)
     )
 
 It contains the basic geometry information of the 3D bounding box.

--- a/tensorbay/dataset/frame.py
+++ b/tensorbay/dataset/frame.py
@@ -121,21 +121,19 @@ class Frame(UserMutableMapping[str, "DataBase._Type"]):
 
     # def set_pose(
     #     self,
-    #     transform: Transform3D.TransformType = None,
-    #     *,
     #     translation: Optional[Iterable[float]] = (0, 0, 0),
     #     rotation: Transform3D.RotationType = (1, 0, 0, 0),
+    #     *,
+    #     matrix: Optional[MatrixType] = None,
     # ) -> None:
     #     """Set the pose of the current frame.
 
     #     Arguments:
-    #         transform: The transform representing the frame pose in
-    #             a :class:`~tensorbay.geometry.transform.Transform3D` object
-    #             or a 4x4 or 3x4 transformation matrix.
     #         translation: Translation of the frame pose in a sequence of [x, y, z].
     #         rotation: Rotation of the frame pose in a sequence of [w, x, y, z]
-    #             or a 3x3 rotation matrix
     #             or a numpy quaternion object.
+    #         matrix: The transform representing the frame pose in
+    #             a 4x4 or 3x4 transform matrix.
 
     #     """
-    #     self._pose = Transform3D(transform, translation=translation, rotation=rotation)
+    #     self._pose = Transform3D(translation, rotation, matrix=matrix)

--- a/tensorbay/geometry/tests/test_box.py
+++ b/tensorbay/geometry/tests/test_box.py
@@ -96,33 +96,30 @@ class TestBox3D:
         translation = Vector3D(1, 2, 3)
         rotation = quaternion(0, 1, 0, 0)
         size = Vector3D(1, 2, 3)
-        transform = Transform3D(translation=translation, rotation=rotation)
 
-        box3d = Box3D(transform)
-        assert box3d.translation == translation
-        assert box3d.rotation == rotation
-
-        box3d = Box3D(translation=translation, rotation=rotation, size=size)
+        box3d = Box3D(size, translation, rotation)
         assert box3d.translation == translation
         assert box3d.rotation == rotation
         assert box3d.size == size
 
     def test_eq(self):
-        box3d_1 = Box3D()
-        box3d_2 = Box3D()
-        box3d_3 = Box3D(translation=[1, 2, 3])
+        box3d_1 = Box3D((1, 1, 1))
+        box3d_2 = Box3D((1, 1, 1))
+        box3d_3 = Box3D(size=(1, 1, 1), translation=[1, 2, 3])
         assert (box3d_1 == box3d_2) == True
         assert (box3d_1 == box3d_3) == False
 
     def test_rmul(self):
-        transform = Transform3D(translation=[1, 2, 3], rotation=quaternion(0, 1, 0, 0))
+        transform = Transform3D([1, 2, 3], quaternion(0, 1, 0, 0))
         quaternion_1 = quaternion(1, 2, 3, 4)
-        box3d = Box3D(transform)
+        box3d = Box3D(size=(1, 1, 1), translation=[1, 2, 3], rotation=quaternion(0, 1, 0, 0))
         assert box3d.__rmul__(transform) == Box3D(
-            translation=[2, 0, 0], rotation=quaternion(-1, 0, 0, 0)
+            size=(1, 1, 1), translation=[2, 0, 0], rotation=quaternion(-1, 0, 0, 0)
         )
         assert box3d.__rmul__(quaternion_1) == Box3D(
-            translation=[1.7999999999999996, 2, 2.6], rotation=quaternion(-2, 1, 4, -3)
+            size=(1, 1, 1),
+            translation=[1.7999999999999996, 2, 2.6],
+            rotation=quaternion(-2, 1, 4, -3),
         )
         assert box3d.__rmul__(1) == NotImplemented
 
@@ -137,11 +134,7 @@ class TestBox3D:
 
     def test_dumps(self):
 
-        box3d = Box3D(
-            translation=Vector3D(1, 2, 3),
-            rotation=quaternion(0, 1, 0, 0),
-            size=Vector3D(1, 2, 3),
-        )
+        box3d = Box3D(Vector3D(1, 2, 3), Vector3D(1, 2, 3), quaternion(0, 1, 0, 0))
         assert box3d.dumps() == _DATA_3D
 
     def test_iou(self):

--- a/tensorbay/geometry/tests/test_transform.py
+++ b/tensorbay/geometry/tests/test_transform.py
@@ -19,34 +19,30 @@ class TestTransform3D:
     def test_init(self):
         sequence = [[1, 0, 0, 1], [0, 1, 0, 1]]
         with pytest.raises(ValueError):
-            Transform3D(sequence)
+            Transform3D(matrix=sequence)
 
-        transform = Transform3D(None)
+        transform = Transform3D()
         assert transform.translation == Vector3D(0.0, 0.0, 0.0)
         assert transform.rotation == quaternion(1.0, 0.0, 0.0, 0.0)
 
         sequence = [[1, 0, 0, 1], [0, 1, 0, 1], [0, 0, 1, 1]]
-        transform = Transform3D(sequence)
+        transform = Transform3D(matrix=sequence)
         assert transform.translation == Vector3D(1, 1, 1)
         assert transform.rotation == quaternion(1.0, -0.0, -0.0, -0.0)
 
         numpy = np.array(sequence)
-        transform = Transform3D(numpy)
+        transform = Transform3D(matrix=numpy)
         assert transform.translation == Vector3D(1, 1, 1)
         assert transform.rotation == quaternion(1.0, -0.0, -0.0, -0.0)
 
-        transform_1 = Transform3D(transform)
-        assert transform_1.translation == Vector3D(1, 1, 1)
-        assert transform_1.rotation == quaternion(1.0, -0.0, -0.0, -0.0)
-
-        transform = Transform3D(translation=[1, 2, 3], rotation=[1, 0, 0, 0])
+        transform = Transform3D([1, 2, 3], [1, 0, 0, 0])
         assert transform.translation == Vector3D(1, 2, 3)
         assert transform.rotation == quaternion(1.0, 0.0, 0.0, 0.0)
 
     def test_eq(self):
-        transform_1 = Transform3D(translation=[1, 2, 3], rotation=[1, 0, 0, 0])
-        transform_2 = Transform3D(translation=[1, 2, 3], rotation=[1, 0, 0, 0])
-        transform_3 = Transform3D(translation=[1, 1, 1], rotation=[1, 0, 0, 0])
+        transform_1 = Transform3D([1, 2, 3], [1, 0, 0, 0])
+        transform_2 = Transform3D([1, 2, 3], [1, 0, 0, 0])
+        transform_3 = Transform3D([1, 1, 1], [1, 0, 0, 0])
         assert (transform_1 == transform_2) == True
         assert (transform_1 == transform_3) == False
 
@@ -55,9 +51,9 @@ class TestTransform3D:
         sequence_2 = [[1, 2, 3], [4, 5, 6]]
         sequence_3 = ["a", "b", "c"]
         quaternion_1 = quaternion(0, 1, 0, 0)
-        transform_1 = Transform3D(translation=[1, 2, 3], rotation=[0, 1, 0, 0])
-        transform_2 = Transform3D(translation=[2, 0, 0], rotation=[-1, 0, 0, 0])
-        transform_3 = Transform3D(translation=[1, 2, 3], rotation=[-1, 0, 0, 0])
+        transform_1 = Transform3D([1, 2, 3], [0, 1, 0, 0])
+        transform_2 = Transform3D([2, 0, 0], [-1, 0, 0, 0])
+        transform_3 = Transform3D([1, 2, 3], [-1, 0, 0, 0])
 
         with pytest.raises(TypeError):
             transform_1 * 1
@@ -70,9 +66,9 @@ class TestTransform3D:
 
     def test_rmul(self):
         quaternion_1 = quaternion(0, 1, 0, 0)
-        transform_1 = Transform3D(translation=[1, 2, 3], rotation=[0, 1, 0, 0])
-        transform_2 = Transform3D(translation=[1, -2, -3], rotation=[-1, 0, 0, 0])
-        transform_3 = Transform3D(translation=["a", "b", "c"], rotation=[-1, 0, 0, 0])
+        transform_1 = Transform3D([1, 2, 3], [0, 1, 0, 0])
+        transform_2 = Transform3D([1, -2, -3], [-1, 0, 0, 0])
+        transform_3 = Transform3D(["a", "b", "c"], [-1, 0, 0, 0])
 
         with pytest.raises(TypeError):
             1 * transform_1
@@ -80,7 +76,7 @@ class TestTransform3D:
         assert transform_3.__rmul__(quaternion_1) == NotImplemented
 
     def test_create(self):
-        transform = Transform3D(translation=[1, 2, 3], rotation=[0, 1, 0, 0])
+        transform = Transform3D([1, 2, 3], [0, 1, 0, 0])
         assert Transform3D._create(Vector3D(1, 2, 3), quaternion(0, 1, 0, 0)) == transform
 
     def test_loads(self):
@@ -89,7 +85,7 @@ class TestTransform3D:
         assert transform.rotation == quaternion(1.0, 0.0, 0.0, 0.0)
 
     def test_dumps(self):
-        transform = Transform3D(translation=[1, 2, 3], rotation=[1, 0, 0, 0])
+        transform = Transform3D([1, 2, 3], [1, 0, 0, 0])
         assert transform.dumps() == _DATA_TRANSFORM
 
     def test_set_translation(self):
@@ -112,10 +108,10 @@ class TestTransform3D:
 
     def test_as_matrix(self):
         matrix = np.array([[1, 0, 0, 1], [0, -1, 0, 2], [0, 0, -1, 3], [0, 0, 0, 1]])
-        transform = Transform3D(translation=[1, 2, 3], rotation=[0, 1, 0, 0])
+        transform = Transform3D([1, 2, 3], [0, 1, 0, 0])
         np.testing.assert_array_equal(transform.as_matrix(), matrix)
 
     def test_inverse(self):
-        transform_1 = Transform3D(translation=[1, 2, 3], rotation=[0, 1, 0, 0])
-        transform_2 = Transform3D(translation=[-1, 2, 3], rotation=[0, -1, 0, 0])
+        transform_1 = Transform3D([1, 2, 3], [0, 1, 0, 0])
+        transform_2 = Transform3D([-1, 2, 3], [0, -1, 0, 0])
         assert transform_1.inverse() == transform_2

--- a/tensorbay/label/tests/test_label_box.py
+++ b/tensorbay/label/tests/test_label_box.py
@@ -127,10 +127,14 @@ class TestLabeledBox3D:
         translation = Vector3D(1, 2, 3)
         rotation = quaternion(1, 2, 3, 4)
         size = Vector3D(1, 2, 3)
-        transform = Transform3D(translation=translation, rotation=rotation)
 
         labeledbox3d = LabeledBox3D(
-            transform, size=size, category=_CATEGORY, attributes=_ATTRIBUTES, instance=_INSTANCE
+            size=size,
+            translation=translation,
+            rotation=rotation,
+            category=_CATEGORY,
+            attributes=_ATTRIBUTES,
+            instance=_INSTANCE,
         )
 
         assert labeledbox3d.translation == translation
@@ -141,16 +145,23 @@ class TestLabeledBox3D:
         assert labeledbox3d.instance == _INSTANCE
 
     def test_rmul(self):
+        size = [1, 2, 3]
         translation = [1, 2, 3]
         rotation = quaternion(0, 1, 0, 0)
-        transform = Transform3D(translation=translation, rotation=rotation)
+        transform = Transform3D(translation, rotation)
         quaternion_1 = quaternion(1, 2, 3, 4)
 
         labeledbox3d = LabeledBox3D(
-            transform, category=_CATEGORY, attributes=_ATTRIBUTES, instance=_INSTANCE
+            size=size,
+            translation=translation,
+            rotation=rotation,
+            category=_CATEGORY,
+            attributes=_ATTRIBUTES,
+            instance=_INSTANCE,
         )
 
         assert labeledbox3d.__rmul__(transform) == LabeledBox3D(
+            size=size,
             translation=[2, 0, 0],
             rotation=[-1, 0, 0, 0],
             category=_CATEGORY,
@@ -159,6 +170,7 @@ class TestLabeledBox3D:
         )
 
         assert labeledbox3d.__rmul__(quaternion_1) == LabeledBox3D(
+            size=size,
             translation=[1.7999999999999996, 2, 2.6],
             rotation=[-2, 1, 4, -3],
             category=_CATEGORY,
@@ -171,11 +183,28 @@ class TestLabeledBox3D:
     def test_eq(self):
         translation = [1, 2, 3]
         rotation = quaternion(1, 2, 3, 4)
-        transform = Transform3D(translation=translation, rotation=rotation)
 
-        box3d1 = LabeledBox3D(transform, size=[1, 2, 3], category=_CATEGORY, attributes=_ATTRIBUTES)
-        box3d2 = LabeledBox3D(transform, size=[1, 2, 3], category=_CATEGORY, attributes=_ATTRIBUTES)
-        box3d3 = LabeledBox3D(transform, size=[1, 2, 5], category=_CATEGORY, attributes=_ATTRIBUTES)
+        box3d1 = LabeledBox3D(
+            size=[1, 2, 3],
+            translation=translation,
+            rotation=rotation,
+            category=_CATEGORY,
+            attributes=_ATTRIBUTES,
+        )
+        box3d2 = LabeledBox3D(
+            size=[1, 2, 3],
+            translation=translation,
+            rotation=rotation,
+            category=_CATEGORY,
+            attributes=_ATTRIBUTES,
+        )
+        box3d3 = LabeledBox3D(
+            size=[1, 2, 5],
+            translation=translation,
+            rotation=rotation,
+            category=_CATEGORY,
+            attributes=_ATTRIBUTES,
+        )
 
         assert box3d1 == box3d2
         assert box3d1 != box3d3
@@ -195,10 +224,14 @@ class TestLabeledBox3D:
         translation = [1, 2, 3]
         rotation = quaternion(1, 2, 3, 4)
         size = [1, 2, 3]
-        transform = Transform3D(translation=translation, rotation=rotation)
 
         labeledbox3d = LabeledBox3D(
-            transform, size=size, category=_CATEGORY, attributes=_ATTRIBUTES, instance=_INSTANCE
+            size=size,
+            translation=translation,
+            rotation=rotation,
+            category=_CATEGORY,
+            attributes=_ATTRIBUTES,
+            instance=_INSTANCE,
         )
 
         assert labeledbox3d.dumps() == _LABELEDBOX3D_DATA

--- a/tensorbay/opendataset/DeepRoute/loader.py
+++ b/tensorbay/opendataset/DeepRoute/loader.py
@@ -64,10 +64,10 @@ def DeepRoute(path: str) -> Dataset:
             position = annotation["position"]
 
             label = LabeledBox3D(
-                category=annotation["type"],
                 size=(bounding_box["length"], bounding_box["width"], bounding_box["height"]),
                 translation=(position["x"], position["y"], position["z"]),
                 rotation=from_rotation_vector((0, 0, annotation["heading"])),
+                category=annotation["type"],
             )
             data.label.box3d.append(label)
 

--- a/tensorbay/opendataset/NeolixOD/loader.py
+++ b/tensorbay/opendataset/NeolixOD/loader.py
@@ -54,12 +54,6 @@ def NeolixOD(path: str) -> Dataset:
             for label_value_raw in fp:
                 label_value = label_value_raw.rstrip().split()
                 label = LabeledBox3D(
-                    category=label_value[0],
-                    attributes={
-                        "Occlusion": int(label_value[1]),
-                        "Truncation": bool(int(label_value[2])),
-                        "Alpha": float(label_value[3]),
-                    },
                     size=[float(label_value[10]), float(label_value[9]), float(label_value[8])],
                     translation=[
                         float(label_value[11]),
@@ -67,6 +61,12 @@ def NeolixOD(path: str) -> Dataset:
                         float(label_value[13]) + 0.5 * float(label_value[8]),
                     ],
                     rotation=from_rotation_vector((0, 0, float(label_value[14]))),
+                    category=label_value[0],
+                    attributes={
+                        "Occlusion": int(label_value[1]),
+                        "Truncation": bool(int(label_value[2])),
+                        "Alpha": float(label_value[3]),
+                    },
                 )
                 data.label.box3d.append(label)
 

--- a/tensorbay/sensor/tests/test_intrinsics.py
+++ b/tensorbay/sensor/tests/test_intrinsics.py
@@ -27,16 +27,21 @@ class TestCameraMatrix:
             CameraMatrix()
         with pytest.raises(TypeError):
             CameraMatrix(fx=1, fy=2)
-        with pytest.raises(TypeError):
-            CameraMatrix(1, 2, 3, 4)
 
-        camera_matrix_1 = CameraMatrix(_3x3_MATRIX)
+        camera_matrix_1 = CameraMatrix(matrix=_3x3_MATRIX)
 
         assert camera_matrix_1.fx == 1
         assert camera_matrix_1.fy == 4
         assert camera_matrix_1.cx == 3
         assert camera_matrix_1.cy == 5
         assert camera_matrix_1.skew == 2
+
+        camera_matrix_1 = CameraMatrix(1, 2, 3, 4)
+        assert camera_matrix_1.fx == 1
+        assert camera_matrix_1.fy == 2
+        assert camera_matrix_1.cx == 3
+        assert camera_matrix_1.cy == 4
+        assert camera_matrix_1.skew == 0
 
     def test_loads(self):
         cameramatrix = CameraMatrix.loads(_CAMERA_MATRIX_DATA)
@@ -52,7 +57,7 @@ class TestCameraMatrix:
 
         camera_matrix_1 = CameraMatrix(fx=fx, fy=fy, cx=cx, cy=cy, skew=skew)
         camera_matrix_2 = CameraMatrix(fx=fx, fy=fy, cx=cx, cy=cy, skew=skew)
-        camera_matrix_3 = CameraMatrix([[0, 0, 0], [0, 0, 0], [0, 0, 0]])
+        camera_matrix_3 = CameraMatrix(matrix=[[0, 0, 0], [0, 0, 0], [0, 0, 0]])
 
         assert (camera_matrix_1 == camera_matrix_2) == True
         assert (camera_matrix_1 == camera_matrix_3) == False
@@ -64,11 +69,11 @@ class TestCameraMatrix:
         assert camera_matrix.dumps() == _CAMERA_MATRIX_DATA
 
     def test_as_matrix(self):
-        camera_matrix = CameraMatrix(_3x3_MATRIX).as_matrix()
+        camera_matrix = CameraMatrix(matrix=_3x3_MATRIX).as_matrix()
         assert np.all(np.array(camera_matrix) == _3x3_NUMPY)
 
     def test_project(self):
-        camera_matrix = CameraMatrix(_3x3_MATRIX)
+        camera_matrix = CameraMatrix(matrix=_3x3_MATRIX)
 
         with pytest.raises(TypeError):
             camera_matrix.project([])
@@ -206,7 +211,9 @@ class TestCameraIntrinsics:
         assert camera_intrinsics_1.distortion_coefficients.p1 == 5
         assert camera_intrinsics_1.distortion_coefficients.k1 == 6
 
-        camera_intrinsics_2 = CameraIntrinsics([[2, 3, 4], [0, 5, 6], [0, 0, 1]], p1=7, k1=8)
+        camera_intrinsics_2 = CameraIntrinsics(
+            camera_matrix=[[2, 3, 4], [0, 5, 6], [0, 0, 1]], p1=7, k1=8
+        )
 
         assert camera_intrinsics_2.camera_matrix.fx == 2
         assert camera_intrinsics_2.camera_matrix.fy == 5
@@ -216,18 +223,6 @@ class TestCameraIntrinsics:
 
         assert camera_intrinsics_2.distortion_coefficients.p1 == 7
         assert camera_intrinsics_2.distortion_coefficients.k1 == 8
-
-        camera_intrinsics_3 = CameraIntrinsics(
-            fx=1, fy=2, cx=3, cy=4, p1=5, k1=6, _init_distortion=False
-        )
-
-        assert camera_intrinsics_3.camera_matrix.fx == 1
-        assert camera_intrinsics_3.camera_matrix.fy == 2
-        assert camera_intrinsics_3.camera_matrix.cx == 3
-        assert camera_intrinsics_3.camera_matrix.cy == 4
-        assert camera_intrinsics_3.camera_matrix.skew == 0
-
-        assert camera_intrinsics_3.distortion_coefficients == None
 
     def test_loads(self):
         camera_intrinsics = CameraIntrinsics.loads(_CAMERAINTRINSICS_DATA)
@@ -251,7 +246,9 @@ class TestCameraIntrinsics:
     def test_eq(self):
         camera_intrinsics_1 = CameraIntrinsics(fx=1, fy=2, cx=3, cy=4, skew=0, p1=1, k1=2)
         camera_intrinsics_2 = CameraIntrinsics(fx=1, fy=2, cx=3, cy=4, skew=0, p1=1, k1=2)
-        camera_intrinsics_3 = CameraIntrinsics([[0, 0, 0], [0, 0, 0], [0, 0, 0]], p1=0, k1=0)
+        camera_intrinsics_3 = CameraIntrinsics(
+            camera_matrix=[[0, 0, 0], [0, 0, 0], [0, 0, 0]], p1=0, k1=0
+        )
 
         assert (camera_intrinsics_1 == camera_intrinsics_2) == True
         assert (camera_intrinsics_1 == camera_intrinsics_3) == False
@@ -261,11 +258,11 @@ class TestCameraIntrinsics:
         assert camera_intrinsics.dumps() == _CAMERAINTRINSICS_DATA
 
     def test_camera_matrix(self):
-        camera_intrinsics = CameraIntrinsics(_3x3_MATRIX, p1=1, p2=2, k1=1, k2=2)
-        assert camera_intrinsics.camera_matrix == CameraMatrix(_3x3_MATRIX)
+        camera_intrinsics = CameraIntrinsics(camera_matrix=_3x3_MATRIX, p1=1, p2=2, k1=1, k2=2)
+        assert camera_intrinsics.camera_matrix == CameraMatrix(matrix=_3x3_MATRIX)
 
     def test_distortion_coefficients(self):
-        camera_intrinsics = CameraIntrinsics(_3x3_MATRIX, p1=1, p2=2, k1=1, k2=2)
+        camera_intrinsics = CameraIntrinsics(camera_matrix=_3x3_MATRIX, p1=1, p2=2, k1=1, k2=2)
         distortion_coefficients = camera_intrinsics.distortion_coefficients
 
         assert distortion_coefficients == DistortionCoefficients(p1=1, p2=2, k1=1, k2=2)
@@ -285,7 +282,9 @@ class TestCameraIntrinsics:
         )
 
     def test_project(self):
-        camera_intrinsics = CameraIntrinsics([[1, 0, 0], [0, 1, 0], [0, 0, 1]], p1=1, p2=1, k1=1)
+        camera_intrinsics = CameraIntrinsics(
+            camera_matrix=[[1, 0, 0], [0, 1, 0], [0, 0, 1]], p1=1, p2=1, k1=1
+        )
 
         point_1_fisheye_true = camera_intrinsics.project((1, 2), is_fisheye=True)
         point_2_fisheye_true = camera_intrinsics.project((1, 2, 3), is_fisheye=True)

--- a/tensorbay/sensor/tests/test_sensor.py
+++ b/tensorbay/sensor/tests/test_sensor.py
@@ -85,7 +85,7 @@ class TestSensor:
     def test_loads(self):
         camera_1 = Sensor.loads(_CAMERA_DATA)
 
-        assert camera_1.extrinsics == Transform3D(translation=_TRANSLATION, rotation=_ROTATION)
+        assert camera_1.extrinsics == Transform3D(_TRANSLATION, _ROTATION)
         assert camera_1.intrinsics == CameraIntrinsics(
             fx=1, fy=1, cx=1, cy=1, skew=0, p1=1, p2=1, k1=1, k2=1
         )
@@ -102,8 +102,8 @@ class TestLidar:
         assert lidar_1.extrinsics == Transform3D()
 
         lidar_2 = Lidar("test")
-        lidar_2.set_extrinsics(translation=_TRANSLATION, rotation=_ROTATION)
-        assert lidar_2.extrinsics == Transform3D(translation=_TRANSLATION, rotation=_ROTATION)
+        lidar_2.set_extrinsics(_TRANSLATION, _ROTATION)
+        assert lidar_2.extrinsics == Transform3D(_TRANSLATION, _ROTATION)
 
     def test_set_translation(self):
         lidar = Lidar("test")
@@ -117,7 +117,7 @@ class TestLidar:
 
     def test_dumps(self):
         lidar = Lidar("Lidar1")
-        lidar.set_extrinsics(translation=_TRANSLATION, rotation=_ROTATION)
+        lidar.set_extrinsics(_TRANSLATION, _ROTATION)
         contents = lidar.dumps()
         assert contents == _LIDAR_DATA
 
@@ -133,8 +133,8 @@ class TestRadar:
         assert radar_1.extrinsics == Transform3D()
 
         radar_2 = Radar("test")
-        radar_2.set_extrinsics(translation=_TRANSLATION, rotation=_ROTATION)
-        assert radar_2.extrinsics == Transform3D(translation=_TRANSLATION, rotation=_ROTATION)
+        radar_2.set_extrinsics(_TRANSLATION, _ROTATION)
+        assert radar_2.extrinsics == Transform3D(_TRANSLATION, _ROTATION)
 
     def test_set_translation(self):
         radar = Radar("test")
@@ -148,7 +148,7 @@ class TestRadar:
 
     def test_dumps(self):
         radar = Radar("Radar1")
-        radar.set_extrinsics(translation=_TRANSLATION, rotation=_ROTATION)
+        radar.set_extrinsics(_TRANSLATION, _ROTATION)
         contents = radar.dumps()
         assert contents == _RADAR_DATA
 
@@ -164,8 +164,8 @@ class TestCamera:
         assert camera_1.extrinsics == Transform3D()
 
         camera_2 = Camera("test")
-        camera_2.set_extrinsics(translation=_TRANSLATION, rotation=_ROTATION)
-        assert camera_2.extrinsics == Transform3D(translation=_TRANSLATION, rotation=_ROTATION)
+        camera_2.set_extrinsics(_TRANSLATION, _ROTATION)
+        assert camera_2.extrinsics == Transform3D(_TRANSLATION, _ROTATION)
 
     def test_set_translation(self):
         camera = Camera("test")
@@ -195,7 +195,7 @@ class TestCamera:
 
     def test_dumps(self):
         camera = Camera("Camera1")
-        camera.set_extrinsics(translation=_TRANSLATION, rotation=_ROTATION)
+        camera.set_extrinsics(_TRANSLATION, _ROTATION)
         camera.set_camera_matrix(fx=1, fy=1, cx=1, cy=1)
         camera.set_distortion_coefficients(p1=1, p2=1, k1=1, k2=1)
         contents = camera.dumps()
@@ -213,10 +213,8 @@ class TestFisheyeCamera:
         assert fisheye_camera_1.extrinsics == Transform3D()
 
         fisheye_camera_2 = FisheyeCamera("test")
-        fisheye_camera_2.set_extrinsics(translation=_TRANSLATION, rotation=_ROTATION)
-        assert fisheye_camera_2.extrinsics == Transform3D(
-            translation=_TRANSLATION, rotation=_ROTATION
-        )
+        fisheye_camera_2.set_extrinsics(_TRANSLATION, _ROTATION)
+        assert fisheye_camera_2.extrinsics == Transform3D(_TRANSLATION, _ROTATION)
 
     def test_set_translation(self):
         fisheye_camera = FisheyeCamera("test")
@@ -230,7 +228,7 @@ class TestFisheyeCamera:
 
     def test_dumps(self):
         fisheye_camera = FisheyeCamera("FisheyeCamera1")
-        fisheye_camera.set_extrinsics(translation=_TRANSLATION, rotation=_ROTATION)
+        fisheye_camera.set_extrinsics(_TRANSLATION, _ROTATION)
         contents = fisheye_camera.dumps()
         assert contents == _FISHEYE_CAMERA_DATA
 

--- a/tensorbay/utility/__init__.py
+++ b/tensorbay/utility/__init__.py
@@ -5,7 +5,7 @@
 
 """Utility classes."""
 
-from .common import EqMixin, common_loads
+from .common import EqMixin, MatrixType, common_loads
 from .name import NameMixin, NameOrderedDict, NameSortedDict, NameSortedList
 from .repr import ReprMixin, ReprType, repr_config
 from .tbrn import TBRN, TBRNType
@@ -14,6 +14,7 @@ from .user import UserMapping, UserMutableMapping, UserMutableSequence, UserSequ
 
 __all__ = [
     "EqMixin",
+    "MatrixType",
     "NameMixin",
     "NameOrderedDict",
     "NameSortedDict",

--- a/tensorbay/utility/common.py
+++ b/tensorbay/utility/common.py
@@ -12,9 +12,12 @@ which compares all the instance variables.
 
 """
 
-from typing import Any, Type, TypeVar
+from typing import Any, Sequence, Type, TypeVar, Union
+
+import numpy as np
 
 _T = TypeVar("_T")
+MatrixType = Union[Sequence[Sequence[float]], np.ndarray]
 
 
 def common_loads(object_class: Type[_T], contents: Any) -> _T:


### PR DESCRIPTION
- Use "matrix" keyword argument in __init__() of Transfrom3D and CameraMatrix.
- No longer support init from self in Transfrom3D.