### PR TITLE
feat(dataset): use str() instead of ULID.str to transform ULID to str

### DIFF
--- a/tensorbay/client/segment.py
+++ b/tensorbay/client/segment.py
@@ -540,7 +540,7 @@ class FusionSegmentClient(SegmentClientBase):
                 frame_info: Dict[str, Any] = {
                     "segmentName": self._name,
                     "sensorName": sensor_name,
-                    "frameId": frame_id.str,
+                    "frameId": str(frame_id),
                 }
                 if hasattr(data, "timestamp"):
                     frame_info["timestamp"] = data.timestamp

--- a/tensorbay/dataset/frame.py
+++ b/tensorbay/dataset/frame.py
@@ -132,7 +132,7 @@ class Frame(UserMutableMapping[str, "DataBase._Type"]):
         # if self._pose:
         #     contents["pose"] = self._pose.dumps()
         if hasattr(self, "frame_id"):
-            contents["frameId"] = self.frame_id.str
+            contents["frameId"] = str(self.frame_id)
 
         frame = []
         for sensor_name, data in self._data.items():


### PR DESCRIPTION
If user use a "str" rather than "ULID" to initialize a Frame, the
"frame_id" will be a "str". Type "str" does not have ".str" property,
but function "str()" supports both "str" and "ULID". This makes
"Frame.dumps()" and "FusionSegmentClient.upload_frame()" work correctly
even if the "frame_id" is a "str"