### PR TITLE
ci: set astroid version==2.5.2 to fix pylint false positive

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,8 @@ ulid-py
 
 # linter
 pre-commit
-pylint==2.7.2
+pylint==2.7.4
+astroid==2.5.2
 
 # test
 pytest==6.2.2


### PR DESCRIPTION
related issue:
https://github.com/PyCQA/pylint/pull/4334