### PR TITLE
docs(opendataset): standardize the docstring of opendataset dataloaders

### DIFF
--- a/tensorbay/opendataset/AnimalPose/loader.py
+++ b/tensorbay/opendataset/AnimalPose/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of 5 Categories AnimalPose dataset and 7 Categories AnimalPose dataset."""
+# pylint: disable=missing-module-docstring
 
 import json
 import os
@@ -43,40 +42,43 @@ _KEYPOINT_TO_INDEX = {
 
 
 def AnimalPose5(path: str) -> Dataset:
-    """Dataloader of 5 Categories AnimalPose dataset.
+    """Dataloader of the `5 Categories Animal Pose`_ dataset.
+
+    .. _5 Categories Animal Pose: https://sites.google.com/view/animal-pose/
+
+    The file structure should be like::
+
+        <path>
+            keypoint_image_part1/
+                cat/
+                    2007_000549.jpg
+                    2007_000876.jpg
+                    ...
+                ...
+            PASCAL2011_animal_annotation/
+                cat/
+                    2007_000549_1.xml
+                    2007_000876_1.xml
+                    2007_000876_2.xml
+                    ...
+                ...
+            animalpose_image_part2/
+                cat/
+                    ca1.jpeg
+                    ca2.jpeg
+                    ...
+                ...
+            animalpose_anno2/
+                cat/
+                    ca1.xml
+                    ca2.xml
+                ...
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    keypoint_image_part1/
-                        cat/
-                            2007_000549.jpg
-                            2007_000876.jpg
-                            ...
-                        ...
-                    PASCAL2011_animal_annotation/
-                        cat/
-                            2007_000549_1.xml
-                            2007_000876_1.xml
-                            2007_000876_2.xml
-                            ...
-                        ...
-                    animalpose_image_part2/
-                        cat/
-                            ca1.jpeg
-                            ca2.jpeg
-                            ...
-                        ...
-                    animalpose_anno2/
-                        cat/
-                            ca1.xml
-                            ca2.xml
-                        ...
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))
@@ -178,24 +180,27 @@ _DATA_GETTERS = {"part1": _get_data_part1, "part2": _get_data_part2}
 
 
 def AnimalPose7(path: str) -> Dataset:
-    """Dataloader of 7 Categories AnimalPose dataset.
+    """Dataloader of `7 Categories Animal-Pose`_ dataset.
+
+    .. _7 Categories Animal-Pose: https://sites.google.com/view/animal-pose/
+
+    The file structure should be like::
+
+        <path>
+            bndbox_image/
+                antelope/
+                    Img-77.jpg
+                    ...
+                ...
+            bndbox_anno/
+                antelope.json
+                ...
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    bndbox_image/
-                        antelope/
-                            Img-77.jpg
-                            ...
-                        ...
-                    bndbox_anno/
-                        antelope.json
-                        ...
 
     Returns:
-        loaded `Dataset` object.
+        loaded :class:`~tensorbay.dataset.dataset.Dataset` object.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/AnimalsWithAttributes2/loader.py
+++ b/tensorbay/opendataset/AnimalsWithAttributes2/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the Animals with attributes 2 dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 
@@ -16,24 +15,27 @@ DATASET_NAME = "Animals with attributes 2"
 
 
 def AnimalsWithAttributes2(path: str) -> Dataset:
-    """Dataloader of the Animals with attributes 2 dataset.
+    """Dataloader of the `Animals with attributes 2`_ dataset.
+
+    .. _Animals with attributes 2: https://cvml.ist.ac.at/AwA2/
+
+    The file structure should be like::
+
+        <path>
+            classes.txt
+            predicates.txt
+            predicate-matrix-binary.txt
+            JPEGImages/
+                <classname>/
+                    <imagename>.jpg
+                ...
+            ...
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    classes.txt
-                    predicates.txt
-                    predicate-matrix-binary.txt
-                    JPEGImages/
-                        <classname>/
-                            <imagename>.jpg
-                        ...
-                    ...
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/BSTLD/loader.py
+++ b/tensorbay/opendataset/BSTLD/loader.py
@@ -3,8 +3,7 @@
 # Copytright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the BSTLD dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 
@@ -21,33 +20,36 @@ _LABEL_FILENAME_DICT = {
 
 
 def BSTLD(path: str) -> Dataset:
-    """Dataloader of the BSTLD dataset.
+    """Dataloader of the `BSTLD`_ dataset.
+
+    .. _BSTLD: https://hci.iwr.uni-heidelberg.de/content/bosch-small-traffic-lights-dataset
+
+    The file structure should be like::
+
+        <path>
+            rgb/
+                additional/
+                    2015-10-05-10-52-01_bag/
+                        <image_name>.jpg
+                        ...
+                    ...
+                test/
+                    <image_name>.jpg
+                    ...
+                train/
+                    2015-05-29-15-29-39_arastradero_traffic_light_loop_bag/
+                        <image_name>.jpg
+                        ...
+                    ...
+            test.yaml
+            train.yaml
+            additional_train.yaml
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    rgb/
-                        additional/
-                            2015-10-05-10-52-01_bag/
-                                <image_name>.jpg
-                                ...
-                            ...
-                        test/
-                            <image_name>.jpg
-                            ...
-                        train/
-                            2015-05-29-15-29-39_arastradero_traffic_light_loop_bag/
-                                <image_name>.jpg
-                                ...
-                            ...
-                    test.yaml
-                    train.yaml
-                    additional_train.yaml
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     import yaml  # pylint: disable=import-outside-toplevel

--- a/tensorbay/opendataset/BioIDFace/loader.py
+++ b/tensorbay/opendataset/BioIDFace/loader.py
@@ -3,8 +3,7 @@
 # Copytright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the BioID Face Database."""
+# pylint: disable=missing-module-docstring
 
 import os
 from itertools import islice
@@ -19,11 +18,11 @@ DATASET_NAME = "BioID Face Database"
 
 
 def BioIDFace(path: str) -> Dataset:
-    """Dataloader of the BioID Face Database.
+    """Dataloader of the `BioID Face`_ Dataset.
 
-    Arguments:
-        path: The root directory of the dataset.
-            The folder structure should be like::
+    .. BioID Face_: https://www.bioid.com/facedb/
+
+    The folder structure should be like::
 
                 <path>
                     BioID-FaceDatabase-V1.2/
@@ -33,8 +32,11 @@ def BioIDFace(path: str) -> Dataset:
                     points_20/
                         bioid_0000.pts
 
+    Arguments:
+        path: The root directory of the dataset.
+
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/CADC/loader.py
+++ b/tensorbay/opendataset/CADC/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the CADC dataset."""
+# pylint: disable=missing-module-docstring
 
 import json
 import os
@@ -22,52 +21,55 @@ DATASET_NAME = "CADC"
 
 
 def CADC(path: str) -> FusionDataset:
-    """Dataloader of the CADC dataset.
+    """Dataloader of the `CADC`_ dataset.
+
+    .. _CADC: http://cadcd.uwaterloo.ca/index.html
+
+    The file structure should be like::
+
+        <path>
+            2018_03_06/
+                0001/
+                    3d_ann.json
+                    labeled/
+                        image_00/
+                            data/
+                                0000000000.png
+                                0000000001.png
+                                ...
+                            timestamps.txt
+                        ...
+                        image_07/
+                            data/
+                            timestamps.txt
+                        lidar_points/
+                            data/
+                            timestamps.txt
+                        novatel/
+                            data/
+                            dataformat.txt
+                            timestamps.txt
+                ...
+                0018/
+                calib/
+                    00.yaml
+                    01.yaml
+                    02.yaml
+                    03.yaml
+                    04.yaml
+                    05.yaml
+                    06.yaml
+                    07.yaml
+                    extrinsics.yaml
+                    README.txt
+            2018_03_07/
+            2019_02_27/
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    2018_03_06/
-                        0001/
-                            3d_ann.json
-                            labeled/
-                                image_00/
-                                    data/
-                                        0000000000.png
-                                        0000000001.png
-                                        ...
-                                    timestamps.txt
-                                ...
-                                image_07/
-                                    data/
-                                    timestamps.txt
-                                lidar_points/
-                                    data/
-                                    timestamps.txt
-                                novatel/
-                                    data/
-                                    dataformat.txt
-                                    timestamps.txt
-                        ...
-                        0018/
-                        calib/
-                            00.yaml
-                            01.yaml
-                            02.yaml
-                            03.yaml
-                            04.yaml
-                            05.yaml
-                            06.yaml
-                            07.yaml
-                            extrinsics.yaml
-                            README.txt
-                    2018_03_07/
-                    2019_02_27/
 
     Returns:
-        Loaded `FusionDataset` object.
+        Loaded `~tensorbay.dataset.dataset.FusionDataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/CarConnection/loader.py
+++ b/tensorbay/opendataset/CarConnection/loader.py
@@ -3,8 +3,8 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the The Car Connection Picture dataset."""
+# pylint: disable=missing-module-docstring
+# pylint: disable=line-too-long
 
 import os
 from typing import Union
@@ -18,18 +18,21 @@ DATASET_NAME = "The Car Connection Picture"
 
 
 def CarConnection(path: str) -> Dataset:
-    """Dataloader of the The Car Connection Picture dataset.
+    """Dataloader of `The Car Connection Picture`_ dataset.
+
+    .. _The Car Connection Picture: https://github.com/nicolas-gervais/predicting-car-price-from-scraped-data/tree/master/picture-scraper # noqa: E501
+
+    The file structure should be like::
+
+        <path>
+            <imagename>.jpg
+            ...
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    <imagename>.jpg
-                    ...
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/CoinImage/loader.py
+++ b/tensorbay/opendataset/CoinImage/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the Coin Image dataset."""
+# pylint: disable=missing-module-docstring
 
 import csv
 import os
@@ -18,19 +17,22 @@ DATASET_NAME = "Coin Image"
 
 
 def CoinImage(path: str) -> Dataset:
-    """Dataloader of the Coin Image dataset.
+    """Dataloader of the `Coin Image`_ dataset.
+
+    .. _Coin Image: https://cvl.tuwien.ac.at/research/cvl-databases/coin-image-dataset/
+
+    The file structure should be like::
+
+        <path>
+            classes.csv
+            <imagename>.png
+            ...
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    classes.csv
-                    <imagename>.png
-                    ...
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/CompCars/loader.py
+++ b/tensorbay/opendataset/CompCars/loader.py
@@ -3,8 +3,7 @@
 # Copytright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the CompCars dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 from typing import Any, Dict, List, Tuple
@@ -22,43 +21,46 @@ _SEGMENT_SPLIT_FILES = (
 
 
 def CompCars(path: str) -> Dataset:
-    """Dataloader of the CompCars dataset.
+    """Dataloader of the `CompCars`_ dataset.
+
+    .. _CompCars: http://mmlab.ie.cuhk.edu.hk/datasets/comp_cars/index.html
+
+    The file structure should be like::
+
+        <path>
+            data/
+                image/
+                    <make name id>/
+                        <model name id>/
+                            <year>/
+                                <image name>.jpg
+                                ...
+                            ...
+                        ...
+                    ...
+                label/
+                    <make name id>/
+                        <model name id>/
+                            <year>/
+                                <image name>.txt
+                                ...
+                            ...
+                        ...
+                    ...
+                misc/
+                    attributes.txt
+                    car_type.mat
+                    make_model_name.mat
+                train_test_split/
+                    classification/
+                        train.txt
+                        test.txt
 
     Arguments:
-        path: The root path of dataset.
-            The file structure should be like::
-
-                <path>
-                    data/
-                        image/
-                            <make name id>/
-                                <model name id>/
-                                    <year>/
-                                        <image name>.jpg
-                                        ...
-                                    ...
-                                ...
-                            ...
-                        label/
-                            <make name id>/
-                                <model name id>/
-                                    <year>/
-                                        <image name>.txt
-                                        ...
-                                    ...
-                                ...
-                            ...
-                        misc/
-                            attributes.txt
-                            car_type.mat
-                            make_model_name.mat
-                        train_test_split/
-                            classification/
-                                train.txt
-                                test.txt
+        path: The root directory of the dataset.
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.join(os.path.abspath(os.path.expanduser(path)), "data")

--- a/tensorbay/opendataset/DeepRoute/loader.py
+++ b/tensorbay/opendataset/DeepRoute/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the DeepRoute Open Dataset."""
+# pylint: disable=missing-module-docstring
 
 import json
 import os
@@ -19,26 +18,29 @@ DATASET_NAME = "DeepRoute Open Dataset"
 
 
 def DeepRoute(path: str) -> Dataset:
-    """Dataloader of the DeepRoute Open Dataset.
+    """Dataloader of the `DeepRoute`_ Open Dataset.
+
+    .. _DeepRoute: https://www.graviti.cn/open-datasets/DeepRoute
+
+    The file structure should be like::
+
+        <path>
+            pointcloud/
+                00001.bin
+                00002.bin
+                ...
+                10000.bin
+            groundtruth/
+                00001.txt
+                00002.txt
+                ...
+                10000.txt
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    pointcloud/
-                        00001.bin
-                        00002.bin
-                        ...
-                        10000.bin
-                    groundtruth/
-                        00001.txt
-                        00002.txt
-                        ...
-                        10000.txt
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/DogsVsCats/loader.py
+++ b/tensorbay/opendataset/DogsVsCats/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the DogsVsCats dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 
@@ -17,25 +16,28 @@ _SEGMENTS = {"train": True, "test": False}
 
 
 def DogsVsCats(path: str) -> Dataset:
-    """Dataloader of the DogsVsCats dataset.
+    """Dataloader of the `DogsVsCats`_ dataset.
+
+    .. _DogsVsCats: https://www.kaggle.com/c/dogs-vs-cats
+
+    The file structure should be like::
+
+        <path>
+            train/
+                cat.0.jpg
+                ...
+                dog.0.jpg
+                ...
+            test/
+                1000.jpg
+                1001.jpg
+                ...
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    train/
-                        cat.0.jpg
-                        ...
-                        dog.0.jpg
-                        ...
-                    test/
-                        1000.jpg
-                        1001.jpg
-                        ...
 
     Returns:
-        Loaded ``Dataset`` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/DownsampledImagenet/loader.py
+++ b/tensorbay/opendataset/DownsampledImagenet/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the Downsampled Imagenet dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 
@@ -16,28 +15,31 @@ SEGMENT_NAMES = ["train_32x32", "train_64x64", "valid_32x32", "valid_64x64"]
 
 
 def DownsampledImagenet(path: str) -> Dataset:
-    """Dataloader of the Downsampled Imagenet dataset.
+    """Dataloader of the `Downsampled Imagenet`_ dataset.
+
+    .. _Downsampled Imagenet: http://image-net.org/small/download.php
+
+    The file structure should be like::
+
+        <path>
+            valid_32x32/
+                <imagename>.png
+                ...
+            valid_64x64/
+                <imagename>.png
+                ...
+            train_32x32/
+                <imagename>.png
+                ...
+            train_64x64/
+                <imagename>.png
+                ...
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    valid_32x32/
-                        <imagename>.png
-                        ...
-                    valid_64x64/
-                        <imagename>.png
-                        ...
-                    train_32x32/
-                        <imagename>.png
-                        ...
-                    train_64x64/
-                        <imagename>.png
-                        ...
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/Elpv/loader.py
+++ b/tensorbay/opendataset/Elpv/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the elpv dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 
@@ -15,20 +14,23 @@ DATASET_NAME = "elpv"
 
 
 def Elpv(path: str) -> Dataset:
-    """Dataloader of the elpv dataset.
+    """Dataloader of the `elpv`_ dataset.
+
+    .. _elpv: https://github.com/zae-bayern/elpv-dataset
+
+    The file structure should be like::
+
+        <path>
+            labels.csv
+            images/
+                cell0001.png
+                ...
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    labels.csv
-                    images/
-                        cell0001.png
-                        ...
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/FLIC/loader.py
+++ b/tensorbay/opendataset/FLIC/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the FLIC dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 from typing import Any, Dict, Iterator, Tuple
@@ -17,20 +16,23 @@ _VALID_KEYPOINT_INDICES = [0, 1, 2, 3, 4, 5, 6, 9, 12, 13, 16]
 
 
 def FLIC(path: str) -> Dataset:
-    """Dataloader of the FLIC dataset.
+    """Dataloader of the `FLIC`_ dataset.
+
+    .. _FLIC: https://bensapp.github.io/flic-dataset.html
+
+    The folder structure should be like::
+
+        <path>
+            exampls.mat
+            images/
+                2-fast-2-furious-00003571.jpg
+                ...
 
     Arguments:
         path: The root directory of the dataset.
-            The folder structure should be like::
-
-                <path>
-                    exampls.mat
-                    images/
-                        2-fast-2-furious-00003571.jpg
-                        ...
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     from scipy.io import loadmat  # pylint: disable=import-outside-toplevel

--- a/tensorbay/opendataset/FSDD/loader.py
+++ b/tensorbay/opendataset/FSDD/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the Free Spoken Digit dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 
@@ -25,20 +24,23 @@ _METADATA = {
 
 
 def FSDD(path: str) -> Dataset:
-    """Dataloader of the Free Spoken Digit dataset.
+    """Dataloader of the `Free Spoken Digit`_ dataset.
+
+    .. _Free Spoken Digit: https://github.com/Jakobovski/free-spoken-digit-dataset
+
+    The file structure should be like::
+
+        <path>
+            recordings/
+                0_george_0.wav
+                0_george_1.wav
+                ...
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    recordings/
-                        0_george_0.wav
-                        0_george_1.wav
-                        ...
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     label_map = {}

--- a/tensorbay/opendataset/Flower/loader.py
+++ b/tensorbay/opendataset/Flower/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the 17 Category Flower dataset and the 102 Category Flower dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 
@@ -18,15 +17,15 @@ _SEGMENT_NAMES_102 = {"train": "trnid", "validation": "valid", "test": "tstid"}
 
 
 def Flower17(path: str) -> Dataset:
-    """Dataloader of the 17 Category Flower dataset.
+    """Dataloader of the `17 Category Flower`_ dataset.
+
+    .. _17 Category Flower: http://www.robots.ox.ac.uk/~vgg/data/flowers/17/index.html
 
     The dataset are 3 separate splits.
     The results in the paper are averaged over the 3 splits.
     We just use (trn1, val1, tst1) to split it.
 
-    Arguments:
-        path: The root directory of the dataset.
-            The file structure should be like::
+    The file structure should be like::
 
                 <path>
                     jpg/
@@ -34,8 +33,11 @@ def Flower17(path: str) -> Dataset:
                         ...
                     datasplits.mat
 
+    Arguments:
+        path: The root directory of the dataset.
+
     Returns:
-        A loaded dataset.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     from scipy.io import loadmat  # pylint: disable=import-outside-toplevel
@@ -60,21 +62,24 @@ def Flower17(path: str) -> Dataset:
 
 
 def Flower102(path: str) -> Dataset:
-    """Dataloader of the 102 Category Flower dataset.
+    """Dataloader of the `102 Category Flower`_ dataset.
+
+    .. _102 Category Flower: http://www.robots.ox.ac.uk/~vgg/data/flowers/102/index.html
+
+    The file structure should be like::
+
+        <path>
+            jpg/
+                image_00001.jpg
+                ...
+            imagelabels.mat
+            setid.mat
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    jpg/
-                        image_00001.jpg
-                        ...
-                    imagelabels.mat
-                    setid.mat
 
     Returns:
-        A loaded dataset.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     from scipy.io import loadmat  # pylint: disable=import-outside-toplevel

--- a/tensorbay/opendataset/HalpeFullBody/loader.py
+++ b/tensorbay/opendataset/HalpeFullBody/loader.py
@@ -3,8 +3,8 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the Halpe Full-Body Human Keypoints and HOI-Det dataset."""
+# pylint: disable=missing-module-docstring
+# pylint: disable=line-too-long
 
 import json
 import os
@@ -23,26 +23,29 @@ _SEGMENT_SPLIT = (
 
 
 def HalpeFullBody(path: str) -> Dataset:
-    """Dataloader of the Halpe Full-Body Human Keypoints and HOI-Det dataset.
+    """Dataloader of the `Halpe Full-Body Human Keypoints and HOI-Det`_ dataset.
+
+    .. _Halpe Full-Body Human Keypoints and HOI-Det: https://github.com/Fang-Haoshu/Halpe-FullBody/ # noqa: E501
+
+    The folder structure should be like::
+
+        <path>
+            halpe_train_v1.json
+            halpe_val_v1.json
+            hico_20160224_det/
+                images/
+                    train2015/
+                        HICO_train2015_00000001.jpg
+                        ...
+            val2017/
+                000000000139.jpg
+                ...
 
     Arguments:
         path: The root directory of the dataset.
-            The folder structure should be like::
-
-                <path>
-                    halpe_train_v1.json
-                    halpe_val_v1.json
-                    hico_20160224_det/
-                        images/
-                            train2015/
-                                HICO_train2015_00000001.jpg
-                                ...
-                    val2017/
-                        000000000139.jpg
-                        ...
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/HardHatWorkers/loader.py
+++ b/tensorbay/opendataset/HardHatWorkers/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the Hard Hat Workers dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 from typing import List
@@ -18,22 +17,25 @@ DATASET_NAME = "Hard Hat Workers"
 
 
 def HardHatWorkers(path: str) -> Dataset:
-    """Dataloader of the Hard Hat Workers dataset.
+    """Dataloader of the `Hard Hat Workers`_ dataset.
+
+    .. _Hard Hat Workers: https://makeml.app/datasets/hard-hat-workers
+
+    The file structure should be like::
+
+        <path>
+            annotations/
+                hard_hat_workers0.xml
+                ...
+            images/
+                hard_hat_workers0.png
+                ...
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    annotations/
-                        hard_hat_workers0.xml
-                        ...
-                    images/
-                        hard_hat_workers0.png
-                        ...
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     dataset = Dataset(DATASET_NAME)

--- a/tensorbay/opendataset/HeadPoseImage/loader.py
+++ b/tensorbay/opendataset/HeadPoseImage/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the Head Pose Image dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 import re
@@ -19,26 +18,29 @@ DATASET_NAME = "Head Pose Image"
 
 
 def HeadPoseImage(path: str) -> Dataset:
-    """Dataloader of the Head Pose Image dataset.
+    """Dataloader of the `Head Pose Image`_ dataset.
+
+    .. _Head Pose Image: http://www-prima.inrialpes.fr/perso/Gourier/Faces/HPDatabase.html
+
+    The file structure should be like::
+
+        <path>
+            Person01/
+                person01100-90+0.jpg
+                person01100-90+0.txt
+                person01101-60-90.jpg
+                person01101-60-90.txt
+                ...
+            Person02/
+            Person03/
+            ...
+            Person15/
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    Person01/
-                        person01100-90+0.jpg
-                        person01100-90+0.txt
-                        person01101-60-90.jpg
-                        person01101-60-90.txt
-                        ...
-                    Person02/
-                    Person03/
-                    ...
-                    Person15/
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     dataset = Dataset(DATASET_NAME)

--- a/tensorbay/opendataset/ImageEmotion/loader.py
+++ b/tensorbay/opendataset/ImageEmotion/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the ImageEmotionAbstract dataset and the ImageEmotionArtphoto dataset."""
+# pylint: disable=missing-module-docstring
 
 import csv
 import os
@@ -18,19 +17,22 @@ DATASET_NAME_ARTPHOTO = "ImageEmotion-artphoto"
 
 
 def ImageEmotionAbstract(path: str) -> Dataset:
-    """Dataloader of the ImageEmotionAbstract dataset.
+    """Dataloader of the `ImageEmotionAbstract`_ dataset.
+
+    .. _ImageEmotionAbstract: https://www.imageemotion.org/
+
+    The file structure should be like::
+
+        <path>
+            ABSTRACT_groundTruth.csv
+            abstract_xxxx.jpg
+            ...
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    ABSTRACT_groundTruth.csv
-                    abstract_xxxx.jpg
-                    ...
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))
@@ -59,18 +61,21 @@ def ImageEmotionAbstract(path: str) -> Dataset:
 
 
 def ImageEmotionArtphoto(path: str) -> Dataset:
-    """Dataloader of the ImageEmotionArtphoto dataset.
+    """Dataloader of the `ImageEmotionArtphoto`_ dataset.
+
+    .. _ImageEmotionArtphoto: https://www.imageemotion.org/
+
+    The file structure should be like::
+
+        <path>
+            <filename>.jpg
+            ...
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    <filename>.jpg
-                    ...
 
     Returns:
-        Loaded `Dataset` object
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/JHU_CROWD/loader.py
+++ b/tensorbay/opendataset/JHU_CROWD/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the JHU-CROWD++ dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 from typing import Dict, List
@@ -20,26 +19,29 @@ _WEATHER_CONDITION_MAP = {0: "no weather degradationi", 1: "fog/haze", 2: "rain"
 
 
 def JHU_CROWD(path: str) -> Dataset:
-    """Dataloader of the JHU-CROWD++ dataset.
+    """Dataloader of the `JHU-CROWD++`_ dataset.
+
+    .. _JHU-CROWD++: http://www.crowd-counting.com/
+
+    The file structure should be like::
+
+        <path>
+            train/
+                images/
+                    0000.jpg
+                    ...
+                gt/
+                    0000.txt
+                    ...
+                image_labels.txt
+            test/
+            val/
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    train/
-                        images/
-                            0000.jpg
-                            ...
-                        gt/
-                            0000.txt
-                            ...
-                        image_labels.txt
-                    test/
-                    val/
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     dataset = Dataset(DATASET_NAME)

--- a/tensorbay/opendataset/KenyanFood/loader.py
+++ b/tensorbay/opendataset/KenyanFood/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the Kenyan Food or Nonfood dataset and Kenyan Food Type dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 
@@ -19,27 +18,30 @@ SEGMENTS_FOOD_OR_NONFOOD = {"test": "test.txt", "train": "train.txt"}
 
 
 def KenyanFoodOrNonfood(path: str) -> Dataset:
-    """Dataloader of the Kenyan Food or Nonfood dataset.
+    """Dataloader of the `Kenyan Food or Nonfood`_ dataset.
+
+    .. _Kenyan Food or Nonfood: https://github.com/monajalal/Kenyan-Food
+
+    The file structure should be like::
+
+        <path>
+            images/
+                food/
+                    236171947206673742.jpg
+                    ...
+                nonfood/
+                    168223407.jpg
+                    ...
+            data.csv
+            split.py
+            test.txt
+            train.txt
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                        images/
-                            food/
-                                236171947206673742.jpg
-                                ...
-                            nonfood/
-                                168223407.jpg
-                                ...
-                        data.csv
-                        split.py
-                        test.txt
-                        train.txt
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))
@@ -59,39 +61,42 @@ def KenyanFoodOrNonfood(path: str) -> Dataset:
 
 
 def KenyanFoodType(path: str) -> Dataset:
-    """Dataloader of the Kenyan Food Type dataset.
+    """Dataloader of the `Kenyan Food Type`_ dataset.
+
+    .. _Kenyan Food Type: https://github.com/monajalal/Kenyan-Food
+
+    The file structure should be like::
+
+        <path>
+            test.csv
+            test/
+                bhaji/
+                    1611654056376059197.jpg
+                    ...
+                chapati/
+                    1451497832469337023.jpg
+                    ...
+                ...
+            train/
+                bhaji/
+                    190393222473009410.jpg
+                    ...
+                chapati/
+                    1310641031297661755.jpg
+                    ...
+            val/
+                bhaji/
+                    1615408264598518873.jpg
+                    ...
+                chapati/
+                    1553618479852020228.jpg
+                    ...
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    test.csv
-                    test/
-                        bhaji/
-                            1611654056376059197.jpg
-                            ...
-                        chapati/
-                            1451497832469337023.jpg
-                            ...
-                        ...
-                    train/
-                        bhaji/
-                            190393222473009410.jpg
-                            ...
-                        chapati/
-                            1310641031297661755.jpg
-                            ...
-                    val/
-                        bhaji/
-                            1615408264598518873.jpg
-                            ...
-                        chapati/
-                            1553618479852020228.jpg
-                            ...
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/KylbergTexture/loader.py
+++ b/tensorbay/opendataset/KylbergTexture/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the Kylberg Texture dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 
@@ -16,25 +15,28 @@ DATASET_NAME = "Kylberg Texture"
 
 
 def KylbergTexture(path: str) -> Dataset:
-    """Dataloader of the Kylberg Texture dataset.
+    """Dataloader of the `Kylberg Texture`_ dataset.
+
+    .. _Kylberg Texture: http://www.cb.uu.se/~gustaf/texture/
+
+    The file structure should be like::
+
+        <path>
+            originalPNG/
+                <imagename>.png
+                ...
+            withoutRotateAll/
+                <imagename>.png
+                ...
+            RotateAll/
+                <imagename>.png
+                ...
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    originalPNG/
-                        <imagename>.png
-                        ...
-                    withoutRotateAll/
-                        <imagename>.png
-                        ...
-                    RotateAll/
-                        <imagename>.png
-                        ...
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/LISATrafficLight/loader.py
+++ b/tensorbay/opendataset/LISATrafficLight/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the LISA traffic light dataset."""
+# pylint: disable=missing-module-docstring
 
 import csv
 import os
@@ -24,45 +23,48 @@ SUPERCATEGORY_INDEX = {
 
 
 def LISATrafficLight(path: str) -> Dataset:
-    """Dataloader of the LISA traffic light dataset.
+    """Dataloader of the `LISA traffic light`_ dataset.
+
+    .. _LISA traffic light: http://cvrr.ucsd.edu/LISA/datasets.html
+
+    The file structure should be like::
+
+        <path>
+            Annotations/Annotations/
+                daySequence1/
+                daySequence2/
+                dayTrain/
+                    dayClip1/
+                    dayClip10/
+                    ...
+                    dayClip9/
+                nightSequence1/
+                nightSequence2/
+                nightTrain/
+                    nightClip1/
+                    nightClip2/
+                    ...
+                    nightClip5/
+            daySequence1/daySequence1/
+            daySequence2/daySequence2/
+            dayTrain/dayTrain/
+                dayClip1/
+                dayClip10/
+                ...
+                dayClip9/
+            nightSequence1/nightSequence1/
+            nightSequence2/nightSequence2/
+            nightTrain/nightTrain/
+                nightClip1/
+                nightClip2/
+                ...
+                nightClip5/
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    Annotations/Annotations/
-                        daySequence1/
-                        daySequence2/
-                        dayTrain/
-                            dayClip1/
-                            dayClip10/
-                            ...
-                            dayClip9/
-                        nightSequence1/
-                        nightSequence2/
-                        nightTrain/
-                            nightClip1/
-                            nightClip2/
-                            ...
-                            nightClip5/
-                    daySequence1/daySequence1/
-                    daySequence2/daySequence2/
-                    dayTrain/dayTrain/
-                        dayClip1/
-                        dayClip10/
-                        ...
-                        dayClip9/
-                    nightSequence1/nightSequence1/
-                    nightSequence2/nightSequence2/
-                    nightTrain/nightTrain/
-                        nightClip1/
-                        nightClip2/
-                        ...
-                        nightClip5/
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     Raises:
         FileStructureError: When frame number is discontinuous.

--- a/tensorbay/opendataset/LeedsSportsPose/loader.py
+++ b/tensorbay/opendataset/LeedsSportsPose/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the LeedsSportsPose dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 
@@ -17,21 +16,24 @@ DATASET_NAME = "Leeds Sports Pose"
 
 
 def LeedsSportsPose(path: str) -> Dataset:
-    """Dataloader of the LeedsSportsPose dataset.
+    """Dataloader of the `LeedsSportsPose`_ dataset.
+
+    .. _LeedsSportsPose: https://sam.johnson.io/research/lsp.html
+
+    The folder structure should be like::
+
+        <path>
+            joints.mat
+            images/
+                im0001.jpg
+                im0002.jpg
+                ...
 
     Arguments:
         path: The root directory of the dataset.
-            The folder structure should be like::
-
-                <path>
-                    joints.mat
-                    images/
-                        im0001.jpg
-                        im0002.jpg
-                        ...
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     from scipy.io import loadmat  # pylint: disable=import-outside-toplevel

--- a/tensorbay/opendataset/NeolixOD/loader.py
+++ b/tensorbay/opendataset/NeolixOD/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the NeolixOD dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 
@@ -18,21 +17,24 @@ DATASET_NAME = "Neolix OD"
 
 
 def NeolixOD(path: str) -> Dataset:
-    """Dataloader of the NeolixOD dataset.
+    """Dataloader of the `NeolixOD`_ dataset.
+
+    .. _NeolixOD: https://www.graviti.cn/dataset-detail/NeolixOD
+
+    The file structure should be like::
+
+        <path>
+            bins/
+                <id>.bin
+            labels/
+                <id>.txt
+            ...
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    bins/
-                        <id>.bin
-                    labels/
-                        <id>.txt
-                    ...
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/Newsgroups20/loader.py
+++ b/tensorbay/opendataset/Newsgroups20/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the Newsgroups20 dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 
@@ -31,45 +30,48 @@ SEGMENT_DESCRIPTION_DICT = {
 
 
 def Newsgroups20(path: str) -> Dataset:
-    """Dataloader of the Newsgroups20 dataset.
+    """Dataloader of the `Newsgroups20`_ dataset.
+
+    .. _Newsgroups20: http://qwone.com/~jason/20Newsgroups/
+
+    The folder structure should be like::
+
+        <path>
+            20news-18828/
+                alt.atheism/
+                    49960
+                    51060
+                    51119
+                    51120
+                    ...
+                comp.graphics/
+                comp.os.ms-windows.misc/
+                comp.sys.ibm.pc.hardware/
+                comp.sys.mac.hardware/
+                comp.windows.x/
+                misc.forsale/
+                rec.autos/
+                rec.motorcycles/
+                rec.sport.baseball/
+                rec.sport.hockey/
+                sci.crypt/
+                sci.electronics/
+                sci.med/
+                sci.space/
+                soc.religion.christian/
+                talk.politics.guns/
+                talk.politics.mideast/
+                talk.politics.misc/
+                talk.religion.misc/
+            20news-bydate-test/
+            20news-bydate-train/
+            20_newsgroups/
 
     Arguments:
         path: The root directory of the dataset.
-            The folder structure should be like::
-
-                <path>
-                    20news-18828/
-                        alt.atheism/
-                            49960
-                            51060
-                            51119
-                            51120
-                            ...
-                        comp.graphics/
-                        comp.os.ms-windows.misc/
-                        comp.sys.ibm.pc.hardware/
-                        comp.sys.mac.hardware/
-                        comp.windows.x/
-                        misc.forsale/
-                        rec.autos/
-                        rec.motorcycles/
-                        rec.sport.baseball/
-                        rec.sport.hockey/
-                        sci.crypt/
-                        sci.electronics/
-                        sci.med/
-                        sci.space/
-                        soc.religion.christian/
-                        talk.politics.guns/
-                        talk.politics.mideast/
-                        talk.politics.misc/
-                        talk.religion.misc/
-                    20news-bydate-test/
-                    20news-bydate-train/
-                    20_newsgroups/
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/NightOwls/loader.py
+++ b/tensorbay/opendataset/NightOwls/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the NightOwls dataset."""
+# pylint: disable=missing-module-docstring
 
 import json
 import os
@@ -18,27 +17,30 @@ DATASET_NAME = "NightOwls"
 
 
 def NightOwls(path: str) -> Dataset:
-    """Dataloader of the NightOwls dataset.
+    """Dataloader of the `NightOwls`_ dataset.
+
+    .. _NightOwls: http://www.nightowls-dataset.org/
+
+    The file structure should be like::
+
+        <path>
+            nightowls_test/
+                <image_name>.png
+                ...
+            nightowls_training/
+                <image_name>.png
+                ...
+            nightowls_validation/
+                <image_name>.png
+                ...
+            nightowls_training.json
+            nightowls_validation.json
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    nightowls_test/
-                        <image_name>.png
-                        ...
-                    nightowls_training/
-                        <image_name>.png
-                        ...
-                    nightowls_validation/
-                        <image_name>.png
-                        ...
-                    nightowls_training.json
-                    nightowls_validation.json
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/RP2K/loader.py
+++ b/tensorbay/opendataset/RP2K/loader.py
@@ -3,8 +3,7 @@
 # Copytright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the RP2K dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 
@@ -16,27 +15,30 @@ DATASET_NAME = "RP2K"
 
 
 def RP2K(path: str) -> Dataset:
-    """Dataloader of the RP2K dataset.
+    """Dataloader of the `RP2K`_ dataset.
+
+    .. _RP2K: https://www.pinlandata.com/rp2k_dataset
+
+    The file structure of RP2K looks like::
+
+        <path>
+            all/
+                test/
+                    <catagory>/
+                        <image_name>.jpg
+                        ...
+                    ...
+                train/
+                    <catagory>/
+                        <image_name>.jpg
+                        ...
+                    ...
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure of RP2K looks like::
-
-                <path>
-                    all/
-                        test/
-                            <catagory>/
-                                <image_name>.jpg
-                                ...
-                            ...
-                        train/
-                            <catagory>/
-                                <image_name>.jpg
-                                ...
-                            ...
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.join(os.path.abspath(os.path.expanduser(path)), "all")

--- a/tensorbay/opendataset/THCHS30/loader.py
+++ b/tensorbay/opendataset/THCHS30/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the THCHS-30 dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 from itertools import islice
@@ -19,26 +18,29 @@ _SEGMENT_NAME_LIST = ("train", "dev", "test")
 
 
 def THCHS30(path: str) -> Dataset:
-    """Dataloader of the THCHS-30 dataset.
+    """Dataloader of the `THCHS-30`_ dataset.
+
+    .. _THCHS-30: http://166.111.134.19:7777/data/thchs30/README.html
+
+    The file structure should be like::
+
+        <path>
+            lm_word/
+                lexicon.txt
+            data/
+                A11_0.wav.trn
+                ...
+            dev/
+                A11_101.wav
+                ...
+            train/
+            test/
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    lm_word/
-                        lexicon.txt
-                    data/
-                        A11_0.wav.trn
-                        ...
-                    dev/
-                        A11_101.wav
-                        ...
-                    train/
-                    test/
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     dataset = Dataset(DATASET_NAME)

--- a/tensorbay/opendataset/THUCNews/loader.py
+++ b/tensorbay/opendataset/THUCNews/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the THUCNews dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 
@@ -16,24 +15,27 @@ DATASET_NAME = "THUCNews"
 
 
 def THUCNews(path: str) -> Dataset:
-    """Dataloader of the THUCNews dataset.
+    """Dataloader of the `THUCNews`_ dataset.
+
+    .. _THUCNews: http://thuctc.thunlp.org/
+
+    The folder structure should be like::
+
+        <path>
+            <category>/
+                0.txt
+                1.txt
+                2.txt
+                3.txt
+                ...
+            <category>/
+            ...
 
     Arguments:
         path: The root directory of the dataset.
-            The folder structure should be like::
-
-                <path>
-                    <category>/
-                        0.txt
-                        1.txt
-                        2.txt
-                        3.txt
-                        ...
-                    <category>/
-                    ...
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/TLR/loader.py
+++ b/tensorbay/opendataset/TLR/loader.py
@@ -3,8 +3,7 @@
 # Copytright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the TLR dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 from collections import defaultdict
@@ -19,23 +18,26 @@ DATASET_NAME = "TLR"
 
 
 def TLR(path: str) -> Dataset:
-    """Dataloader of the TLR dataset.
+    """Dataloader of the `TLR`_ dataset.
+
+    .. _TLR: http://www.lara.prd.fr/benchmarks/trafficlightsrecognition
+
+    The file structure should like::
+
+        <path>
+            root_path/
+                Lara3D_URbanSeq1_JPG/
+                    frame_011149.jpg
+                    frame_011150.jpg
+                    frame_<frame_index>.jpg
+                    ...
+                Lara_UrbanSeq1_GroundTruth_cvml.xml
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should like::
-
-                <path>
-                    root_path/
-                        Lara3D_URbanSeq1_JPG/
-                            frame_011149.jpg
-                            frame_011150.jpg
-                            frame_<frame_index>.jpg
-                            ...
-                        Lara_UrbanSeq1_GroundTruth_cvml.xml
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     root_path = os.path.abspath(os.path.expanduser(path))

--- a/tensorbay/opendataset/WIDER_FACE/loader.py
+++ b/tensorbay/opendataset/WIDER_FACE/loader.py
@@ -3,8 +3,7 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 # pylint: disable=invalid-name
-
-"""Dataloader of the WIDER FACE dataset."""
+# pylint: disable=missing-module-docstring
 
 import os
 from collections import OrderedDict
@@ -24,34 +23,37 @@ _ATTRIBUTE_MAP_TYPE = Dict[str, List[Union[bool, str]]]
 
 
 def WIDER_FACE(path: str) -> Dataset:
-    """Dataloader of the WIDER FACE dataset.
+    """Dataloader of the `WIDER FACE`_ dataset.
+
+    .. _WIDER FACE: http://shuoyang1213.me/WIDERFACE/
+
+    The file structure should be like::
+
+        <path>
+            WIDER_train/
+                images/
+                    0--Parade/
+                        0_Parade_marchingband_1_100.jpg
+                        0_Parade_marchingband_1_1015.jpg
+                        0_Parade_marchingband_1_1030.jpg
+                        ...
+                    1--Handshaking/
+                    ...
+                    59--people--driving--car/
+                    61--Street_Battle/
+            WIDER_val/
+                ...
+            WIDER_test/
+                ...
+            wider_face_split/
+                wider_face_train_bbx_gt.txt
+                wider_face_val_bbx_gt.txt
 
     Arguments:
         path: The root directory of the dataset.
-            The file structure should be like::
-
-                <path>
-                    WIDER_train/
-                        images/
-                            0--Parade/
-                                0_Parade_marchingband_1_100.jpg
-                                0_Parade_marchingband_1_1015.jpg
-                                0_Parade_marchingband_1_1030.jpg
-                                ...
-                            1--Handshaking/
-                            ...
-                            59--people--driving--car/
-                            61--Street_Battle/
-                    WIDER_val/
-                        ...
-                    WIDER_test/
-                        ...
-                    wider_face_split/
-                        wider_face_train_bbx_gt.txt
-                        wider_face_val_bbx_gt.txt
 
     Returns:
-        Loaded `Dataset` object.
+        Loaded :class:`~tensorbay.dataset.dataset.Dataset` instance.
 
     """
     dataset = Dataset(DATASET_NAME)


### PR DESCRIPTION
Standardize the docstrings as followings:

1. Disable the "missing-module-docstring" error from Flake 8 and Pylint.
2. Add a link to the original dataset web page.
3. Adjust the position of "Arguments" contents.  
4. Add a cross-reference for the return content.