### PR TITLE
ci: rollback github actions cache path to absolute path

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Cache python ${{ matrix.python-version }}
         uses: actions/cache@v2
         with:
-          path: ~/.cache/pip
+          path: /opt/hostedtoolcache/Python/${{ matrix.python-version }}
           key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_unit.yaml
+++ b/.github/workflows/test_unit.yaml
@@ -28,14 +28,14 @@ jobs:
         if: startsWith(matrix.os, 'ubuntu')
         uses: actions/cache@v2
         with:
-          path: ~/.cache/pip
+          path: /opt/hostedtoolcache/Python/${{ matrix.python-version }}
           key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
 
       - name: Cache python ${{ matrix.python-version }} in macos
         if: startsWith(matrix.os, 'macos')
         uses: actions/cache@v2
         with:
-          path: ~/Library/Caches/pip
+          path: /Users/runner/hostedtoolcache/Python/${{ matrix.python-version }}
           key: ${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
 
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
rollback commit: 4b6ef7d
reason:
if not set version for rely packages, github actions cache will auto upgrade it