### PR TITLE
refactor(client): rename "commit_key" to "revision"

### DIFF
--- a/examples/draft_and_commit.py
+++ b/examples/draft_and_commit.py
@@ -64,5 +64,5 @@ commit = dataset_client.get_commit(commit_id)
 # checkout to the draft.
 dataset_client.checkout(draft_number=draft_number)
 # checkout to the commit.
-dataset_client.checkout(commit_key=commit_id)
+dataset_client.checkout(revision=commit_id)
 """"""

--- a/tests/test_datasetclient.py
+++ b/tests/test_datasetclient.py
@@ -389,16 +389,16 @@ class TestDatasetClient:
             dataset_client.checkout()
         # Both commit key and draft number are given
         with pytest.raises(TypeError):
-            dataset_client.checkout(commit_key=commit_1_id, draft_number=3)
-        dataset_client.checkout(commit_key=commit_1_id)
+            dataset_client.checkout(revision=commit_1_id, draft_number=3)
+        dataset_client.checkout(revision=commit_1_id)
         assert dataset_client._status.commit_id == commit_1_id
         # The commit does not exist.
         with pytest.raises(TypeError):
-            dataset_client.checkout(commit_key="123")
+            dataset_client.checkout(revision="123")
         assert dataset_client._status.commit_id == commit_1_id
-        dataset_client.checkout(commit_key="V1")
+        dataset_client.checkout(revision="V1")
         assert dataset_client._status.commit_id == commit_1_id
-        dataset_client.checkout(commit_key="main")
+        dataset_client.checkout(revision="main")
         assert dataset_client._status.commit_id == commit_2_id
 
         dataset_client.create_draft("draft-3")


### PR DESCRIPTION
There are different ways to name a commit object, such as commit id,
branch name or tag name. The word "revision" is been chosen to represent
all these names of a commit.