### PR TITLE
docs(opendataset): adapt name in dataloaders to Tensorbay2.3 standard

### DIFF
--- a/tensorbay/opendataset/AnimalPose/loader.py
+++ b/tensorbay/opendataset/AnimalPose/loader.py
@@ -42,9 +42,9 @@ _KEYPOINT_TO_INDEX = {
 
 
 def AnimalPose5(path: str) -> Dataset:
-    """Dataloader of the `5 Categories Animal Pose`_ dataset.
+    """Dataloader of the `5 Categories Animal-Pose`_ dataset.
 
-    .. _5 Categories Animal Pose: https://sites.google.com/view/animal-pose/
+    .. _5 Categories Animal-Pose: https://sites.google.com/view/animal-pose/
 
     The file structure should be like::
 

--- a/tensorbay/opendataset/BioIDFace/loader.py
+++ b/tensorbay/opendataset/BioIDFace/loader.py
@@ -18,9 +18,9 @@ DATASET_NAME = "BioID Face Database"
 
 
 def BioIDFace(path: str) -> Dataset:
-    """Dataloader of the `BioID Face`_ Dataset.
+    """Dataloader of `The BioID Face`_ Dataset.
 
-    .. BioID Face_: https://www.bioid.com/facedb/
+    .._ The BioID Face: https://www.bioid.com/facedb/
 
     The folder structure should be like::
 

--- a/tensorbay/opendataset/DeepRoute/loader.py
+++ b/tensorbay/opendataset/DeepRoute/loader.py
@@ -18,9 +18,9 @@ DATASET_NAME = "DeepRoute Open Dataset"
 
 
 def DeepRoute(path: str) -> Dataset:
-    """Dataloader of the `DeepRoute`_ Open Dataset.
+    """Dataloader of the `DeepRoute Open Dataset`_.
 
-    .. _DeepRoute: https://www.graviti.cn/open-datasets/DeepRoute
+    .. _DeepRoute Open Dataset: https://www.graviti.cn/open-datasets/DeepRoute
 
     The file structure should be like::
 

--- a/tensorbay/opendataset/DogsVsCats/loader.py
+++ b/tensorbay/opendataset/DogsVsCats/loader.py
@@ -16,9 +16,9 @@ _SEGMENTS = {"train": True, "test": False}
 
 
 def DogsVsCats(path: str) -> Dataset:
-    """Dataloader of the `DogsVsCats`_ dataset.
+    """Dataloader of the `Dogs vs Cats`_ dataset.
 
-    .. _DogsVsCats: https://www.kaggle.com/c/dogs-vs-cats
+    .. _Dogs vs Cats: https://www.kaggle.com/c/dogs-vs-cats
 
     The file structure should be like::
 

--- a/tensorbay/opendataset/ImageEmotion/loader.py
+++ b/tensorbay/opendataset/ImageEmotion/loader.py
@@ -17,9 +17,9 @@ DATASET_NAME_ARTPHOTO = "ImageEmotion-artphoto"
 
 
 def ImageEmotionAbstract(path: str) -> Dataset:
-    """Dataloader of the `ImageEmotionAbstract`_ dataset.
+    """Dataloader of the `Image Emotion-abstract`_ dataset.
 
-    .. _ImageEmotionAbstract: https://www.imageemotion.org/
+    .. _Image Emotion-abstract: https://www.imageemotion.org/
 
     The file structure should be like::
 
@@ -61,9 +61,9 @@ def ImageEmotionAbstract(path: str) -> Dataset:
 
 
 def ImageEmotionArtphoto(path: str) -> Dataset:
-    """Dataloader of the `ImageEmotionArtphoto`_ dataset.
+    """Dataloader of the `Image Emotion-art Photo`_ dataset.
 
-    .. _ImageEmotionArtphoto: https://www.imageemotion.org/
+    .. _Image Emotion-art Photo: https://www.imageemotion.org/
 
     The file structure should be like::
 

--- a/tensorbay/opendataset/LISATrafficLight/loader.py
+++ b/tensorbay/opendataset/LISATrafficLight/loader.py
@@ -23,9 +23,9 @@ SUPERCATEGORY_INDEX = {
 
 
 def LISATrafficLight(path: str) -> Dataset:
-    """Dataloader of the `LISA traffic light`_ dataset.
+    """Dataloader of the `LISA Traffic Light`_ dataset.
 
-    .. _LISA traffic light: http://cvrr.ucsd.edu/LISA/datasets.html
+    .. _LISA Traffic Light: http://cvrr.ucsd.edu/LISA/datasets.html
 
     The file structure should be like::
 

--- a/tensorbay/opendataset/LeedsSportsPose/loader.py
+++ b/tensorbay/opendataset/LeedsSportsPose/loader.py
@@ -16,9 +16,9 @@ DATASET_NAME = "Leeds Sports Pose"
 
 
 def LeedsSportsPose(path: str) -> Dataset:
-    """Dataloader of the `LeedsSportsPose`_ dataset.
+    """Dataloader of the `Leeds Sports Pose`_ dataset.
 
-    .. _LeedsSportsPose: https://sam.johnson.io/research/lsp.html
+    .. _Leeds Sports Pose: https://sam.johnson.io/research/lsp.html
 
     The folder structure should be like::
 

--- a/tensorbay/opendataset/NeolixOD/loader.py
+++ b/tensorbay/opendataset/NeolixOD/loader.py
@@ -17,9 +17,9 @@ DATASET_NAME = "Neolix OD"
 
 
 def NeolixOD(path: str) -> Dataset:
-    """Dataloader of the `NeolixOD`_ dataset.
+    """Dataloader of the `Neolix OD`_ dataset.
 
-    .. _NeolixOD: https://www.graviti.cn/dataset-detail/NeolixOD
+    .. _Neolix OD: https://www.graviti.cn/dataset-detail/NeolixOD
 
     The file structure should be like::
 

--- a/tensorbay/opendataset/Newsgroups20/loader.py
+++ b/tensorbay/opendataset/Newsgroups20/loader.py
@@ -30,9 +30,9 @@ SEGMENT_DESCRIPTION_DICT = {
 
 
 def Newsgroups20(path: str) -> Dataset:
-    """Dataloader of the `Newsgroups20`_ dataset.
+    """Dataloader of the `20 Newsgroups`_ dataset.
 
-    .. _Newsgroups20: http://qwone.com/~jason/20Newsgroups/
+    .. _20 Newsgroups: http://qwone.com/~jason/20Newsgroups/
 
     The folder structure should be like::
 


### PR DESCRIPTION
TensorBay2.3 Standard:

`name` is the unique identifier of a dataset, which is used for generating
`url` and dataset retrieval in TensorBay SDK, CLI and OpenAPI. It can only be
composed of letters, numbers, `-` and `_`.