### PR TITLE
docs: refine version control section in draft_and_commit.rst and tag.rst

### DIFF
--- a/docs/source/version_control/draft_and_commit.rst
+++ b/docs/source/version_control/draft_and_commit.rst
@@ -1,53 +1,20 @@
 ##################
- Draft And Commit
+ Draft and Commit
 ##################
 
-The version control is based on the :ref:`version_control/draft_and_commit:draft` and
-:ref:`version_control/draft_and_commit:commit`.
+The version control is based on the :ref:`reference/glossary:draft` and
+:ref:`reference/glossary:commit`.
 
-In TensorBay SDK, the :class:`~tensorbay.client.gas.GAS` is responsible for operating the datasets, while
-the :class:`~tensorbay.client.dataset.DatasetClient` is for operating content of one dataset
-in the draft or commit. Thus, the dataset client supports the function of version control.
-
-In this section, you’ll learn the relationship between the draft and commit.
-
-*******
-Commit
-*******
-
-Similar with Git, a commit is a version of a dataset,
+Similar with Git, a :ref:`reference/glossary:commit` is a version of a dataset,
 which contains the changes compared with the former commit.
-You can view a certain commit of a dataset based on the given commit ID.
 
-A commit is readable, but is not writable.
-Thus, only read operations such as getting catalog, files and labels are allowed.
-To make changes to a dataset, please create a draft first.
-See :ref:`version_control/draft_and_commit:draft` for details.
+Unlike Git, a :ref:`reference/glossary:draft` is a new concept which represents a workspace in which changing the dataset is allowed.
 
-On the other hand,
-"commit" also represents the action to save the changes inside a :ref:`version_control/draft_and_commit:draft`
-into a commit.
+In TensorBay SDK, the dataset client supplies the function of version control.
 
-******
-Draft
-******
-
-Unlike Git, a draft is a new concept which represents a workspace in which changing the dataset is allowed.
-
-A draft is created based on a :ref:`version_control/draft_and_commit:commit`,
-and the changes inside it will be made into a commit.
-
-There are scenarios when modifications of a dataset are required,
-such as correcting errors, enlarging dataset, adding more types of labels, etc.
-Under these circumstances, you can create a draft, edit the dataset and commit the draft.
-
-***********
-Before Use
-***********
-
-In the next part, you'll learn the basic operations towards draft and commit.
-
-First, a dataset client instance is needed.
+**************
+Authorization
+**************
 
 .. literalinclude:: ../../../examples/draft_and_commit.py
       :language: python
@@ -66,8 +33,7 @@ TensorBay SDK supports creating the draft straightforwardly, which is based on t
       :end-before: """"""
 
 Then the dataset client will change the status to "draft" and store the draft number.
-The draft number will be auto-increasing every time you create a draft.
-The draft number can be found through listing drafts.
+The draft number will be auto-increasing every time a draft is created.
 
 .. literalinclude:: ../../../examples/draft_and_commit.py
       :language: python
@@ -78,7 +44,7 @@ The draft number can be found through listing drafts.
 List Drafts
 ************
 
-Listing the existing :class:`~tensorbay.client.struct.Draft` in TensorBay SDK is simple.
+The draft number can be found through listing drafts.
 
 .. literalinclude:: ../../../examples/draft_and_commit.py
       :language: python
@@ -89,8 +55,6 @@ Listing the existing :class:`~tensorbay.client.struct.Draft` in TensorBay SDK is
 Get Draft
 **********
 
-TensorBay SDK supports getting the :class:`~tensorbay.client.struct.Draft` with the draft number.
-
 .. literalinclude:: ../../../examples/draft_and_commit.py
       :language: python
       :start-after: """Get Draft"""
@@ -100,25 +64,16 @@ TensorBay SDK supports getting the :class:`~tensorbay.client.struct.Draft` with 
 Commit Draft
 *************
 
-TensorBay SDK supports committing the draft, after that the draft will be closed.
+After the commit, the draft will be closed.
 
 .. literalinclude:: ../../../examples/draft_and_commit.py
       :language: python
       :start-after: """Commit Draft"""
       :end-before: """"""
 
-Then the dataset client will change the status to "commit" and store the commit ID.
-
-.. literalinclude:: ../../../examples/draft_and_commit.py
-      :language: python
-      :start-after: """Commit ID Will Be Stored"""
-      :end-before: """"""
-
 ***********
 Get Commit
 ***********
-
-TensorBay SDK supports getting the :class:`~tensorbay.client.struct.Commit` with the commit ID.
 
 .. literalinclude:: ../../../examples/draft_and_commit.py
       :language: python
@@ -129,8 +84,6 @@ TensorBay SDK supports getting the :class:`~tensorbay.client.struct.Commit` with
 List Commits
 *************
 
-Listing the existing :class:`~tensorbay.client.struct.Commit` in TensorBay SDK is simple.
-
 .. literalinclude:: ../../../examples/draft_and_commit.py
       :language: python
       :start-after: """List Commits"""
@@ -139,8 +92,6 @@ Listing the existing :class:`~tensorbay.client.struct.Commit` in TensorBay SDK i
 *********
 Checkout
 *********
-
-The dataset client can checkout to other draft with draft number or to commit with commit id.
 
 .. literalinclude:: ../../../examples/draft_and_commit.py
       :language: python

--- a/docs/source/version_control/tag.rst
+++ b/docs/source/version_control/tag.rst
@@ -2,11 +2,10 @@
  Tag
 #####
 
-TensorBay SDK has the ability to tag specific commits in a dataset's history as being important.
-Typically, people use this functionality to mark release points (v1.0, v2.0 and so on).
-In this section, you'll learn how to list existing :ref:`tags <reference/glossary:tag>`, how to create and delete tags.
+TensorBay supports tagging specific commits in a dataset's history as being important.
+Typically, people use this functionality to mark release revisions (v1.0, v2.0 and so on).
 
-Before operating tags, a dataset client instance with commit is needed.
+Before operating tags, a dataset client instance with existing commit is needed.
 
 .. literalinclude:: ../../../examples/tag.py
       :language: python
@@ -17,28 +16,32 @@ Before operating tags, a dataset client instance with commit is needed.
  Create Tag
 ************
 
-TensorBay SDK supports two approaches of creating the tag.
+TensorBay SDK supports three approaches of creating the tag.
 
-One is creating the tag straightforwardly, which is based on the current commit.
-
-.. literalinclude:: ../../../examples/tag.py
-      :language: python
-      :start-after: """Create Tag"""
-      :end-before: """"""
-
-
-The other is creating the tag when committing.
+First is to create the tag when committing.
 
 .. literalinclude:: ../../../examples/tag.py
       :language: python
       :start-after: """Create Tag When Committing"""
       :end-before: """"""
 
+Second is to create the tag straightforwardly, which is based on the current commit.
+
+.. literalinclude:: ../../../examples/tag.py
+      :language: python
+      :start-after: """Create Tag Straightforwardly"""
+      :end-before: """"""
+
+Third is to create tag on an existing commit.
+
+.. literalinclude:: ../../../examples/tag.py
+      :language: python
+      :start-after: """Create Tag on an Existing Commit"""
+      :end-before: """"""
+
 *********
  Get Tag
 *********
-
-TensorBay SDK supports getting the :class:`~tensorbay.client.struct.Tag` with the tag name.
 
 .. literalinclude:: ../../../examples/tag.py
       :language: python
@@ -46,10 +49,8 @@ TensorBay SDK supports getting the :class:`~tensorbay.client.struct.Tag` with th
       :end-before: """"""
 
 ***********
- list Tags
+ List Tags
 ***********
-
-Listing the existing :class:`~tensorbay.client.struct.Tag` in TensorBay SDK is simple.
 
 .. literalinclude:: ../../../examples/tag.py
       :language: python
@@ -59,8 +60,6 @@ Listing the existing :class:`~tensorbay.client.struct.Tag` in TensorBay SDK is s
 ************
  Delete Tag
 ************
-
-TensorBay SDK supports deleting the tag with the tag name.
 
 .. literalinclude:: ../../../examples/tag.py
       :language: python

--- a/examples/draft_and_commit.py
+++ b/examples/draft_and_commit.py
@@ -28,8 +28,8 @@ dataset_client.create_draft("draft-1")
 
 """Draft Number Will Be Stored"""
 is_draft = dataset_client.status.is_draft
-draft_number = dataset_client.status.draft_number
 # is_draft = True (True for draft, False for commit)
+draft_number = dataset_client.status.draft_number
 # draft_number = 1
 """"""
 
@@ -43,12 +43,9 @@ draft = dataset_client.get_draft(draft_number=1)
 
 """Commit Draft"""
 dataset_client.commit("commit-1")
-""""""
-
-"""Commit ID Will Be Stored"""
 is_draft = dataset_client.status.is_draft
-commit_id = dataset_client.status.commit_id
 # is_draft = False (True for draft, False for commit)
+commit_id = dataset_client.status.commit_id
 # commit_id = "***"
 """"""
 

--- a/examples/tag.py
+++ b/examples/tag.py
@@ -21,20 +21,20 @@ ACCESS_KEY = "Accesskey-*****"
 gas = GAS(ACCESS_KEY)
 dataset_client = gas.create_dataset("DatasetName")
 dataset_client.create_draft("draft-1")
-dataset_client.commit("commit-1")
-""""""
-
-"""Create Tag"""
-dataset_client.create_tag("Tag-1")
-""""""
-
-"""Delete Tag"""
-dataset_client.delete_tag("Tag-1")
+# do the modifications in this draft
 """"""
 
 """Create Tag When Committing"""
-dataset_client.create_draft("draft-2")
-dataset_client.commit("commit-2", tag="Tag-1")
+dataset_client.commit("commit-1", tag="Tag-1")
+""""""
+
+"""Create Tag Straightforwardly"""
+dataset_client.create_tag("Tag-1")
+""""""
+
+"""Create Tag on an Existing Commit"""
+commit_id = dataset_client.status.commit_id
+dataset_client.create_tag("Tag-1", revision=commit_id)
 """"""
 
 """Get Tag"""
@@ -43,4 +43,8 @@ tag = dataset_client.get_tag("Tag-1")
 
 """List Tags"""
 tags = dataset_client.list_tags()
+""""""
+
+"""Delete Tag"""
+dataset_client.delete_tag("Tag-1")
 """"""


### PR DESCRIPTION
draft_and_commit.rst:
- description of Client
- simplify  the explanation of draft and commit, and add links to
glossary
- change the links of classes to the links of glossary
- correct the title "Draft And Commit" as "Draft and Commit"
- change the title "Before Use" as "Authorization"
- correct the order of notation and code in draft_and_commit.py
- "... is simple" -> "supports"
- delete redundant description

tag.rst:
- "has the ability to" -> supports
- mark release points -> mark release revision
- do not commit after creating a dataset in tag.py
- add the third way to create tag
- delete redundant description