### PR TITLE
docs: refine "Configuration" of "getting_started_with_cli.rst"

### DIFF
--- a/docs/source/tensorbay_cli/getting_started_with_cli.rst
+++ b/docs/source/tensorbay_cli/getting_started_with_cli.rst
@@ -37,13 +37,7 @@ The following is the general format for TBRN:
  Configuration
 ***************
 
-Use the command below to configure the accessKey.
-
-.. code:: console
-
-   $ gas config [accessKey]
-
-AccessKey_ is used for identification when using TensorBay to operate on dataset.
+An accessKey_ is used for identification when using TensorBay to operate datasets.
 
 .. _accesskey: https://gas.graviti.cn/tensorbay/developer
 


### PR DESCRIPTION
- delete redundant description for "gas config"
- polish description for accessKey