### PR TITLE
docs: modify cross-references and hyperlinks in related rst files

### DIFF
--- a/docs/source/advanced_features/fusion_dataset.rst
+++ b/docs/source/advanced_features/fusion_dataset.rst
@@ -6,10 +6,7 @@ Fusion dataset represents datasets with data collected from multiple sensors.
 Typical examples of fusion dataset are some autonomous driving datasets,
 such as `nuScenes`_ and `KITTI-tracking`_.
 
-See :ref:`this page <reference/dataset_structure:dataset>`
-for the comparison between the fusion dataset and the dataset.
-
-.. _nuScenes: https://gas.graviti.cn/dataset/graviti-open-dataset/nuScenes
+.. _nuScenes: https://gas.graviti.cn/dataset/motional/nuScenes
 .. _KITTI-tracking: https://gas.graviti.cn/dataset/data-decorators/KITTITracking
 
 .. toctree::

--- a/docs/source/examples/read_dataset_class.rst
+++ b/docs/source/examples/read_dataset_class.rst
@@ -2,9 +2,10 @@
  Read "Dataset" Class
 ######################
 
-This topic describes how to read the :class:`~tensorbay.dataset.dataset.Dataset` instance after
-the "BSTLD" dataset have been :ref:`organized <examples/BSTLD:Organize Dataset>`.
-See `this page <https://gas.graviti.cn/dataset/data-decorators/BSTLD>`_  for more details about this dataset.
+This topic describes how to read the :class:~tensorbay.dataset.dataset.Dataset class
+using the BSTLD_ dataset as an example.
+
+.. _BSTLD: https://gas.graviti.cn/dataset/data-decorators/BSTLD
 
 As mentioned in :ref:`features/dataset_management:Dataset Management`, a
 :ref:`reference/glossary:Dataloader` is needed to get a :class:`~tensorbay.dataset.dataset.Dataset`.

--- a/docs/source/features/dataset_management.rst
+++ b/docs/source/features/dataset_management.rst
@@ -14,21 +14,20 @@ This topic describes the key operations towards datasets, including:
 ******************
 
 TensorBay SDK supports methods to organize local datasets
-into uniform TensorBay dataset strucutre
-(:ref:`ref <reference/dataset_structure:Dataset Structure>`).
+into uniform TensorBay :ref:`dataset structure <reference/dataset_structure:Dataset Structure>`.
 The typical steps to organize a local dataset:
 
-- First, write a dataloader (:ref:`ref <reference/glossary:dataloader>`)
+- First, write a :ref:`dataloader <reference/glossary:dataloader>`
   to load the whole local dataset into a :class:`~tensorbay.dataset.dataset.Dataset`
-  instance,
-- Second, write a catalog (:ref:`ref <reference/dataset_structure:Catalog>`)
+  instance.
+- Second, write a :ref:`catalog <reference/dataset_structure:Catalog>`
   to store all the label meta information inside a dataset.
 
 .. note::
 
    A catalog is needed only if there is label information inside the dataset.
-
-:ref:`This part <examples/bstld:Organize Dataset>` is an example for organizing a dataset.
+   
+Take the :ref:`Organization of BSTLD <examples/bstld:Organize Dataset>` as an example.
 
 
 ****************
@@ -39,12 +38,9 @@ There are two usages for the organized local dataset
 (i.e. the initialized :class:`~tensorbay.dataset.dataset.Dataset` instance):
 
 - Upload it to TensorBay.
-- Use it directly.
+- Use it from local.
 
 This section mainly discusses the uploading operation.
-See :ref:`this example <examples/read_dataset_class:Read "Dataset" class>`
-for details about the latter usage.
-
 There are plenty of benefits of uploading local datasets to TensorBay.
 
 - **REUSE**: uploaded datasets can be reused without preprocessing again.
@@ -52,8 +48,7 @@ There are plenty of benefits of uploading local datasets to TensorBay.
 - **VISUALIZATION**: uploaded datasets can be visualized without coding.
 - **VERSION CONTROL**: different versions of one dataset can be uploaded and controlled conveniently.
 
-
-:ref:`This part <examples/bstld:Upload Dataset>` is an example for uploading a dataset.
+Take the :ref:`Uploading of BSTLD <examples/bstld:Upload Dataset>` as an example.
 
 **************
  Read Dataset
@@ -62,7 +57,9 @@ There are plenty of benefits of uploading local datasets to TensorBay.
 Two types of datasets can be read from TensorBay:
 
 - Datasets uploaded by yourself as mentioned in :ref:`features/dataset_management:Upload Dataset`.
-- Datasets uplaoded by the community (i.e. the `open datasets`_).
+- Datasets uploaded by the community (check them on the `Open Datasets`_ platform.).
+
+Take the :ref:`Reading of BSTLD <examples/bstld:Read Dataset>` as an example.
 
 .. note::
 
@@ -70,11 +67,10 @@ Two types of datasets can be read from TensorBay:
 
 .. note::
 
-   Visit our `Graviti AI Service(GAS)`_ platform to check the dataset details,
-   such as dataset name, version information, etc.
-
-:ref:`This part <examples/bstld:Read Dataset>` is an example for reading a dataset.
+   Visit `my datasets(or team datasets)`_ panel of `TensorBay`_ platform to check all
+   datasets that can be read.
 
 .. _fork: https://docs.graviti.cn/guide/opendataset/fork
-.. _open datasets: https://www.graviti.cn/open-datasets
-.. _Graviti AI Service(GAS): https://www.graviti.cn/tensorBay
+.. _Open Datasets: https://www.graviti.cn/open-datasets
+.. _my datasets(or team datasets): https://gas.graviti.cn/tensorbay/dataset-list
+.. _TensorBay: https://gas.graviti.cn/tensorbay/

--- a/docs/source/quick_start/getting_started_with_tensorbay.rst
+++ b/docs/source/quick_start/getting_started_with_tensorbay.rst
@@ -25,9 +25,10 @@ To verify the SDK and CLI version, run the following command:
 Before using TensorBay SDK, please finish the following registration steps:
 
 - Please visit `Graviti AI Service(GAS)`_ to sign up.
-- Please visit `this page <https://gas.graviti.cn/tensorbay/developer>`_ to get an AccessKey.
+- Please visit `Graviti Developer Tools`_ to get an AccessKey.
 
-.. _graviti ai service(gas): https://www.graviti.cn/tensorBay
+.. _graviti ai service(gas): https://gas.graviti.cn/tensorbay/
+.. _Graviti Developer Tools: https://gas.graviti.cn/tensorbay/developer
 
 .. note::
    An AccessKey is needed to authenticate identity when using TensorBay via SDK or CLI.
@@ -45,8 +46,9 @@ Authorize a Client Instance
       :start-after: """Authorize a Client Instance"""
       :end-before: """"""
 
-See :ref:`this page <tensorbay_cli/getting_started_with_cli:Configuration>` for details
-about authenticating identity via CLI.
+See :ref:`CLI Configuration <tensorbay_cli/getting_started_with_cli:Configuration>` for
+details about authenticating identity via CLI.
+
 
 Create a Dataset 
 ================


### PR DESCRIPTION
Modified Contents:
1. Change "this page" to specific description.
2. Change "this part" to specific description.
3. Delete unnecessary cross-references.
4. Deprecate "(ref)" style cross-references and hyperlinks.