### PR TITLE
test(client): fix incorrect raise and mark known failed case as "xfail"

### DIFF
--- a/tests/test_datasetclient.py
+++ b/tests/test_datasetclient.py
@@ -7,6 +7,7 @@
 
 import pytest
 
+from tensorbay import __version__
 from tensorbay.client import GAS, GASSegmentError
 from tensorbay.client.struct import Draft
 from tensorbay.dataset import Data, Frame, FusionSegment, Segment
@@ -669,6 +670,7 @@ class TestDatasetClient:
 
         gas_client.delete_dataset(dataset_name)
 
+    @pytest.mark.xfail(__version__ < "1.5.0", reason="not supported at least until v1.5.0")
     def test_draft_and_top_commit_inherit(self, accesskey, url, tmp_path):
         gas_client = GAS(access_key=accesskey, url=url)
         dataset_name = get_random_dataset_name()

--- a/tests/test_gas.py
+++ b/tests/test_gas.py
@@ -255,7 +255,7 @@ class TestGAS:
         assert segment1[0].path == "hello0.txt"
         assert not segment1[0].label
 
-        with pytest.raises(ResponseError):
+        with pytest.raises(TypeError):
             gas_client.upload_dataset(dataset, draft_number=draft_number + 1)
 
         gas_client.delete_dataset(dataset_name)

--- a/tests/test_segmentclient.py
+++ b/tests/test_segmentclient.py
@@ -8,6 +8,7 @@
 import pytest
 import ulid
 
+from tensorbay import __version__
 from tensorbay.client.gas import GAS
 from tensorbay.dataset.data import Data, Label
 from tensorbay.dataset.frame import Frame
@@ -227,6 +228,7 @@ class TestSegmentClient:
 
         gas_client.delete_dataset(dataset_name)
 
+    @pytest.mark.xfail(__version__ < "1.5.0", reason="not supported at least until v1.5.0")
     def test_upload_label(self, accesskey, url, tmp_path):
         gas_client = GAS(access_key=accesskey, url=url)
         dataset_name = get_random_dataset_name()


### PR DESCRIPTION
1. Set sleep time after calling asynchronous api.(Now ignore)
2. Adapt with the check function in "datasetClient.checkout()".
3. No longer check the equility of input and outpust sensor.(Now ignore)