### PR TITLE
refactor: refine the error message of unexpected status code

### DIFF
--- a/tensorbay/client/requests.py
+++ b/tensorbay/client/requests.py
@@ -154,7 +154,9 @@ class UserSession(Session):  # pylint: disable=too-few-public-methods
         try:
             response = super().request(method, url, *args, **kwargs)
             if response.status_code not in (200, 201):
-                logger.error("Invalid state code!%s", ResponseLogging(response))
+                logger.error(
+                    "Unexpected status code(%d)!%s", response.status_code, ResponseLogging(response)
+                )
                 raise ResponseError(response)
             logger.debug(ResponseLogging(response))
             return response

--- a/tensorbay/exception.py
+++ b/tensorbay/exception.py
@@ -94,10 +94,9 @@ class ResponseError(TensorBayClientException):
     def __init__(self, response: Response) -> None:
         super().__init__()
         self.response = response
-        self.status_code = response.status_code
 
     def __str__(self) -> str:
-        return f"Invalid state code({self.status_code})! {self.response.url}"
+        return f"Unexpected status code({self.response.status_code})! {self.response.url}"
 
 
 class TensorBayOpendatasetException(TensorBayException):


### PR DESCRIPTION
1. Use the word "Unexpected" rather than "Invalid".
2. Fix the typo "state code" to "status code".
3. Remove "self.status_code" and use "self.response.status_code" instead