### PR TITLE
docs(opendataset): amend names in dataloaders to Tensorbay2.3 standard

### DIFF
--- a/tensorbay/opendataset/AnimalPose/loader.py
+++ b/tensorbay/opendataset/AnimalPose/loader.py
@@ -14,8 +14,8 @@ from ...geometry import Keypoint2D
 from ...label import LabeledBox2D, LabeledKeypoints2D
 from .._utility import glob
 
-DATASET_NAME_5 = "5 Categories Animal-Pose"
-DATASET_NAME_7 = "7 Categories Animal-Pose"
+DATASET_NAME_5 = "AnimalPose5"
+DATASET_NAME_7 = "AnimalPose7"
 
 _KEYPOINT_TO_INDEX = {
     "L_Eye": 0,

--- a/tensorbay/opendataset/AnimalsWithAttributes2/loader.py
+++ b/tensorbay/opendataset/AnimalsWithAttributes2/loader.py
@@ -11,7 +11,7 @@ from ...dataset import Data, Dataset
 from ...label import Classification
 from .._utility import glob
 
-DATASET_NAME = "Animals with attributes 2"
+DATASET_NAME = "AnimalsWithAttributes2"
 
 
 def AnimalsWithAttributes2(path: str) -> Dataset:

--- a/tensorbay/opendataset/BioIDFace/loader.py
+++ b/tensorbay/opendataset/BioIDFace/loader.py
@@ -14,7 +14,7 @@ from ...geometry import Keypoint2D
 from ...label import LabeledKeypoints2D
 from .._utility import glob
 
-DATASET_NAME = "BioID Face Database"
+DATASET_NAME = "BioIDFace"
 
 
 def BioIDFace(path: str) -> Dataset:

--- a/tensorbay/opendataset/CarConnection/loader.py
+++ b/tensorbay/opendataset/CarConnection/loader.py
@@ -14,7 +14,7 @@ from ...label import AttributeInfo, Classification
 from ...utility import NameOrderedDict
 from .._utility import glob
 
-DATASET_NAME = "The Car Connection Picture"
+DATASET_NAME = "CarConnectionPicture"
 
 
 def CarConnection(path: str) -> Dataset:

--- a/tensorbay/opendataset/CoinImage/loader.py
+++ b/tensorbay/opendataset/CoinImage/loader.py
@@ -13,7 +13,7 @@ from ...dataset import Data, Dataset
 from ...label import Classification
 from .._utility import glob
 
-DATASET_NAME = "Coin Image"
+DATASET_NAME = "CoinImage"
 
 
 def CoinImage(path: str) -> Dataset:

--- a/tensorbay/opendataset/DeepRoute/loader.py
+++ b/tensorbay/opendataset/DeepRoute/loader.py
@@ -14,7 +14,7 @@ from ...dataset import Data, Dataset
 from ...label import LabeledBox3D
 from .._utility import glob
 
-DATASET_NAME = "DeepRoute Open Dataset"
+DATASET_NAME = "DeepRoute"
 
 
 def DeepRoute(path: str) -> Dataset:

--- a/tensorbay/opendataset/DogsVsCats/loader.py
+++ b/tensorbay/opendataset/DogsVsCats/loader.py
@@ -11,7 +11,7 @@ from ...dataset import Data, Dataset
 from ...label import Classification
 from .._utility import glob
 
-DATASET_NAME = "Dogs vs Cats"
+DATASET_NAME = "DogsVsCats"
 _SEGMENTS = {"train": True, "test": False}
 
 

--- a/tensorbay/opendataset/DownsampledImagenet/loader.py
+++ b/tensorbay/opendataset/DownsampledImagenet/loader.py
@@ -10,7 +10,7 @@ import os
 from ...dataset import Data, Dataset, Segment
 from .._utility import glob
 
-DATASET_NAME = "Downsampled Imagenet"
+DATASET_NAME = "DownsampledImagenet"
 SEGMENT_NAMES = ["train_32x32", "train_64x64", "valid_32x32", "valid_64x64"]
 
 

--- a/tensorbay/opendataset/Elpv/loader.py
+++ b/tensorbay/opendataset/Elpv/loader.py
@@ -10,7 +10,7 @@ import os
 from ...dataset import Data, Dataset
 from ...label import Classification
 
-DATASET_NAME = "elpv"
+DATASET_NAME = "Elpv"
 
 
 def Elpv(path: str) -> Dataset:

--- a/tensorbay/opendataset/FSDD/loader.py
+++ b/tensorbay/opendataset/FSDD/loader.py
@@ -11,7 +11,7 @@ from ...dataset import Data, Dataset
 from ...label import Classification
 from .._utility import glob
 
-DATASET_NAME = "Free Spoken Digit"
+DATASET_NAME = "FSDD"
 
 _METADATA = {
     "jackson": {"gender": "male", "accent": "USA/neutral", "language": "english"},

--- a/tensorbay/opendataset/Flower/loader.py
+++ b/tensorbay/opendataset/Flower/loader.py
@@ -10,8 +10,8 @@ import os
 from ...dataset import Data, Dataset
 from ...label import Classification
 
-DATASET_NAME_17 = "17 Category Flower"
-DATASET_NAME_102 = "102 Category Flower"
+DATASET_NAME_17 = "Flower17"
+DATASET_NAME_102 = "Flower102"
 _SEGMENT_NAMES_17 = {"train": "trn1", "validation": "val1", "test": "tst1"}
 _SEGMENT_NAMES_102 = {"train": "trnid", "validation": "valid", "test": "tstid"}
 

--- a/tensorbay/opendataset/HalpeFullBody/loader.py
+++ b/tensorbay/opendataset/HalpeFullBody/loader.py
@@ -14,7 +14,7 @@ from ...dataset import Data, Dataset
 from ...geometry import Keypoint2D
 from ...label import Classification, LabeledBox2D, LabeledKeypoints2D
 
-DATASET_NAME = "Halpe Full-Body Human Keypoints and HOI-Det"
+DATASET_NAME = "HalpeFullBody"
 
 _SEGMENT_SPLIT = (
     ("train", "halpe_train_v1.json", os.path.join("hico_20160224_det", "images", "train2015")),

--- a/tensorbay/opendataset/HardHatWorkers/loader.py
+++ b/tensorbay/opendataset/HardHatWorkers/loader.py
@@ -13,7 +13,7 @@ from ...dataset import Data, Dataset
 from ...label import LabeledBox2D
 from .._utility import glob
 
-DATASET_NAME = "Hard Hat Workers"
+DATASET_NAME = "HardHatWorkers"
 
 
 def HardHatWorkers(path: str) -> Dataset:

--- a/tensorbay/opendataset/HeadPoseImage/loader.py
+++ b/tensorbay/opendataset/HeadPoseImage/loader.py
@@ -14,7 +14,7 @@ from ...dataset import Data, Dataset
 from ...label import LabeledBox2D
 from .._utility import glob
 
-DATASET_NAME = "Head Pose Image"
+DATASET_NAME = "HeadPoseImage"
 
 
 def HeadPoseImage(path: str) -> Dataset:

--- a/tensorbay/opendataset/ImageEmotion/loader.py
+++ b/tensorbay/opendataset/ImageEmotion/loader.py
@@ -12,8 +12,8 @@ from ...dataset import Data, Dataset
 from ...label import Classification
 from .._utility import glob
 
-DATASET_NAME_ABSTRACT = "ImageEmotion-abstract"
-DATASET_NAME_ARTPHOTO = "ImageEmotion-artphoto"
+DATASET_NAME_ABSTRACT = "ImageEmotionAbstract"
+DATASET_NAME_ARTPHOTO = "ImageEmotionArtPhoto"
 
 
 def ImageEmotionAbstract(path: str) -> Dataset:

--- a/tensorbay/opendataset/JHU_CROWD/loader.py
+++ b/tensorbay/opendataset/JHU_CROWD/loader.py
@@ -13,7 +13,7 @@ from ...label import Classification, LabeledBox2D
 from .._utility import glob
 
 SEGMENT_LIST = ["train", "val", "test"]
-DATASET_NAME = "JHU-CROWD++"
+DATASET_NAME = "JHU-CROWD"
 _OCCLUSION_MAP = {1: "visible", 2: "partial-occlusion", 3: "full-occlusion"}
 _WEATHER_CONDITION_MAP = {0: "no weather degradationi", 1: "fog/haze", 2: "rain", 3: "snow"}
 

--- a/tensorbay/opendataset/KenyanFood/loader.py
+++ b/tensorbay/opendataset/KenyanFood/loader.py
@@ -11,8 +11,8 @@ from ...dataset import Data, Dataset
 from ...label import Classification
 from .._utility import glob
 
-DATASET_NAME_FOOD_TYPE = "Kenyan Food Type"
-DATASET_NAME_FOOD_OR_NONFOOD = "Kenyan Food or Nonfood"
+DATASET_NAME_FOOD_TYPE = "KenyanFoodType"
+DATASET_NAME_FOOD_OR_NONFOOD = "KenyanFoodOrNonfood"
 SEGMENTS_FOOD_TYPE = ["test", "train", "val"]
 SEGMENTS_FOOD_OR_NONFOOD = {"test": "test.txt", "train": "train.txt"}
 

--- a/tensorbay/opendataset/KylbergTexture/loader.py
+++ b/tensorbay/opendataset/KylbergTexture/loader.py
@@ -11,7 +11,7 @@ from ...dataset import Data, Dataset
 from ...label import Classification
 from .._utility import glob
 
-DATASET_NAME = "Kylberg Texture"
+DATASET_NAME = "KylbergTexture"
 
 
 def KylbergTexture(path: str) -> Dataset:

--- a/tensorbay/opendataset/LISATrafficLight/loader.py
+++ b/tensorbay/opendataset/LISATrafficLight/loader.py
@@ -14,7 +14,7 @@ from ...exception import FileStructureError
 from ...label import Classification, LabeledBox2D
 from .._utility import glob
 
-DATASET_NAME = "LISA Traffic Light"
+DATASET_NAME = "LISATrafficLight"
 
 SUPERCATEGORY_INDEX = {
     "frameAnnotationsBOX.csv": "BOX",

--- a/tensorbay/opendataset/LeedsSportsPose/loader.py
+++ b/tensorbay/opendataset/LeedsSportsPose/loader.py
@@ -12,7 +12,7 @@ from ...geometry import Keypoint2D
 from ...label import LabeledKeypoints2D
 from .._utility import glob
 
-DATASET_NAME = "Leeds Sports Pose"
+DATASET_NAME = "LeedsSportsPose"
 
 
 def LeedsSportsPose(path: str) -> Dataset:

--- a/tensorbay/opendataset/NeolixOD/loader.py
+++ b/tensorbay/opendataset/NeolixOD/loader.py
@@ -13,7 +13,7 @@ from ...dataset import Data, Dataset
 from ...label import LabeledBox3D
 from .._utility import glob
 
-DATASET_NAME = "Neolix OD"
+DATASET_NAME = "NeolixOD"
 
 
 def NeolixOD(path: str) -> Dataset:

--- a/tensorbay/opendataset/Newsgroups20/loader.py
+++ b/tensorbay/opendataset/Newsgroups20/loader.py
@@ -11,7 +11,7 @@ from ...dataset import Data, Dataset
 from ...label import Classification
 from .._utility import glob
 
-DATASET_NAME = "20 Newsgroups"
+DATASET_NAME = "Newsgroups20"
 SEGMENT_DESCRIPTION_DICT = {
     "20_newsgroups": "Original 20 Newsgroups data set",
     "20news-bydate-train": (

--- a/tensorbay/opendataset/WIDER_FACE/loader.py
+++ b/tensorbay/opendataset/WIDER_FACE/loader.py
@@ -13,7 +13,7 @@ from typing import Dict, Iterator, List, Union
 from ...dataset import Data, Dataset
 from ...label import Classification, LabeledBox2D
 
-DATASET_NAME = "WIDER FACE"
+DATASET_NAME = "WIDER_FACE"
 _SEGMENT_LIST = {
     "test": "wider_face_test_filelist.txt",
     "train": "wider_face_train_bbx_gt.txt",


### PR DESCRIPTION
TensorBay2.3 Standard:

`name` is the unique identifier of a dataset, which is used for generating
`url` and dataset retrieval in TensorBay SDK, CLI and OpenAPI. It can only be
composed of letters, numbers, `-` and `_`.