### PR TITLE
fix(opendataset): remove Classification and Box2D label in HalpeFullBody

### DIFF
--- a/tensorbay/opendataset/HalpeFullBody/catalog.json
+++ b/tensorbay/opendataset/HalpeFullBody/catalog.json
@@ -270,19 +270,5 @@
                 "visible": "TERNARY"
             }
         ]
-    },
-    "BOX2D": {},
-    "CLASSIFICATION": {
-        "attributes": [
-            {
-                "name": "hoi",
-                "type": "array",
-                "items": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 600
-                }
-            }
-        ]
     }
 }

--- a/tensorbay/opendataset/HalpeFullBody/loader.py
+++ b/tensorbay/opendataset/HalpeFullBody/loader.py
@@ -12,7 +12,7 @@ from typing import Any, Dict
 
 from ...dataset import Data, Dataset
 from ...geometry import Keypoint2D
-from ...label import Classification, LabeledBox2D, LabeledKeypoints2D
+from ...label import LabeledKeypoints2D
 
 DATASET_NAME = "HalpeFullBody"
 
@@ -82,10 +82,5 @@ def _get_data(image_path: str, annotation: Dict[str, Any]) -> Data:
         keypoints.append(Keypoint2D(x, y, v if v in (0, 1, 2) else 2))  # pylint: disable=no-member
 
     data.label.keypoints2d = [keypoints]
-
-    data.label.box2d = [LabeledBox2D.from_xywh(*annotation["bbox"])]
-
-    if "hoi" in annotation.keys():
-        data.label.classification = Classification(attributes={"hoi": annotation["hoi"]})
 
     return data


### PR DESCRIPTION
the label format of Box2D is not uniform in the dataset
issue link: https://github.com/Fang-Haoshu/Halpe-FullBody/issues/4

annotations for "hoi" in Classification label lack important
information