### PR TITLE
fix(sensor): only loads intrinsics and extrinsics with valid value

### DIFF
--- a/tensorbay/sensor/sensor.py
+++ b/tensorbay/sensor/sensor.py
@@ -125,7 +125,8 @@ class Sensor(NameMixin, TypeMixin[SensorType]):
 
     def _loads(self, contents: Dict[str, Any]) -> None:
         super()._loads(contents)
-        if "extrinsics" in contents:
+        extrinsics = contents.get("extrinsics")
+        if extrinsics:
             self.extrinsics = Transform3D.loads(contents["extrinsics"])
 
     @staticmethod
@@ -352,7 +353,8 @@ class Camera(Sensor):
 
     def _loads(self, contents: Dict[str, Any]) -> None:
         super()._loads(contents)
-        if "intrinsics" in contents:
+        intrinsics = contents.get("intrinsics")
+        if intrinsics:
             self.intrinsics = CameraIntrinsics.loads(contents["intrinsics"])
 
     @classmethod


### PR DESCRIPTION
Resolve the issue that KeyError raised when calling:
`segment = FusionSegment("", dataset_client)`

Issue Closed: https://github.com/Graviti-AI/tensorbay-python-sdk/issues/455