### PR TITLE
ci: update linters: "isort", "black", "flake8" and "markdownlint-cli"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.7.0
+    rev: v5.8.0
     hooks:
       - id: isort
         types: [python]
@@ -27,14 +27,14 @@ repos:
         args: ["--profile=black", "-w 100", "--thirdparty=tensorbay"]
 
   - repo: https://github.com/ambv/black
-    rev: 20.8b1
+    rev: 21.4b0
     hooks:
       - id: black
         types: [python]
         args: ["-l 100"]
 
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.4
+    rev: 3.9.1
     hooks:
       - id: flake8
         types: [python]
@@ -102,7 +102,7 @@ repos:
           ]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.26.0
+    rev: v0.27.1
     hooks:
       - id: markdownlint
         types: [markdown]


### PR DESCRIPTION
- isort: v5.7.0 -> v5.8.0
- black: 20.8b1 -> 21.4b0
- flake8: 3.8.4 -> 3.9.1
- markdownlint-cli: v0.26.0 -> v0.27.1