### PR TITLE
refactor(client): remove start & stop args in list_auth_storage_configs

### DIFF
--- a/tensorbay/client/gas.py
+++ b/tensorbay/client/gas.py
@@ -145,14 +145,8 @@ class GAS:
 
         return config
 
-    def list_auth_storage_configs(
-        self, *, start: int = 0, stop: int = sys.maxsize
-    ) -> PagingList[Dict[str, Any]]:
+    def list_auth_storage_configs(self) -> PagingList[Dict[str, Any]]:
         """List auth storage configs.
-
-        Arguments:
-            start: The index to start.
-            stop: The index to stop.
 
         Returns:
             The PagingList of all auth storage configs.
@@ -161,7 +155,6 @@ class GAS:
         return PagingList(
             lambda offset, limit: self._generate_auth_storage_configs(None, offset, limit),
             128,
-            slice(start, stop),
         )
 
     @overload


### PR DESCRIPTION
Arguments "start" and "stop" in list method is deprecated in v1.3.0.