### PR TITLE
docs: refine "Usage" in request configuration related docs

### DIFF
--- a/docs/source/advanced_features/request_configuration.rst
+++ b/docs/source/advanced_features/request_configuration.rst
@@ -38,10 +38,6 @@ Note that the default settings can satisfy most use cases.
 Usage
 =====
 
-Use upload `LISATrafficLight`_ dataset as an exmaple:
-
-.. _LISATrafficLight: https://gas.graviti.cn/dataset/hello-dataset/LISATrafficLight
-
 .. literalinclude:: ../../../examples/request_configuration.py
    :language: python
    :start-after: """Example of request config"""

--- a/docs/source/advanced_features/use_internal_endpoint.rst
+++ b/docs/source/advanced_features/use_internal_endpoint.rst
@@ -27,16 +27,8 @@ and reading datasets.
 Usage
 =====
 
-For users with unstable network, we recommend the following solution:
-
-   #. Make sure that a cloud server in a specific region is available.
-   #. Create and upload datasets to TensorBay storage space which is in the same region as your cloud server.
-   #. Read the datasets from your cloud server using the internal endpoint. 
-
-Use upload `LISATrafficLight`_ dataset as an exmaple, set `is_internal` to `True` when using
-internal endpoint:
-
-.. _LISATrafficLight: https://gas.graviti.cn/dataset/hello-dataset/LISATrafficLight
+If the endpoint of the cloud server is the same as the TensorBay storage, set `is_internal` to `True`
+to use the internal endpoint for obtaining a faster network speed.
 
 .. literalinclude:: ../../../examples/use_internal_endpoint.py
    :language: python

--- a/examples/request_configuration.py
+++ b/examples/request_configuration.py
@@ -15,14 +15,14 @@
 
 """Example of request config"""
 from tensorbay import GAS
-from tensorbay.client.requests import config
-from tensorbay.opendataset import LISATrafficLight
+from tensorbay.client import config
 
+# Enlarge timeout and max_retries of configuration.
 config.timeout = 40
 config.max_retries = 4
 
-gas = GAS(access_key="Accesskey-***")
+gas = GAS("<YOUR_ACCESSKEY>")
 
-dataset = LISATrafficLight("/path/to/dataset")
-gas.upload_dataset(dataset)
+# The configs will apply to all the requests sent by TensorBay SDK.
+gas.list_dataset_names()
 """"""

--- a/examples/use_internal_endpoint.py
+++ b/examples/use_internal_endpoint.py
@@ -16,16 +16,23 @@
 
 """Usage of Upload Dataset By Internal Endpoint"""
 from tensorbay import GAS
-from tensorbay.client.requests import config
-from tensorbay.opendataset import LISATrafficLight
+from tensorbay.client import config
+from tensorbay.dataset import Data, Dataset
 
-DATASET_NAME = "LISA Traffic Light"
-
+# Set is_internal to True for using internal endpoint.
 config.is_internal = True
 
-gas = GAS(access_key="Accesskey-***")
-gas.create_dataset(DATASET_NAME)
+gas = GAS("<YOUR_ACCESSKEY>")
 
-dataset = LISATrafficLight("/path/to/dataset")
-gas.upload_dataset(dataset)
+# Organize the local dataset by the "Dataset" class before uploading.
+dataset = Dataset("DatasetName")
+
+segment = dataset.create_segment()
+segment.append(Data("0000001.jpg"))
+segment.append(Data("0000002.jpg"))
+
+# All the data will be uploaded through internal endpoint.
+dataset_client = gas.upload_dataset(dataset)
+
+dataset_client.commit("Initial commit")
 """"""


### PR DESCRIPTION
Refine contents as below:
1. Change import path of "config" from "requests" to "client" in code block.
2. Use general uploading process instead specific dataset example in code block.
3. Change the description of purpose of "Usage" in "Use Internal Endpoint".