### PR TITLE
perf(client): stop checking the commit_id in DatasetClientBase.__init__

### DIFF
--- a/tensorbay/client/dataset.py
+++ b/tensorbay/client/dataset.py
@@ -70,7 +70,7 @@ class DatasetClientBase:  # pylint: disable=too-many-public-methods
 
         self._status = CommitStatus()
         if commit_id:
-            self.checkout(revision=commit_id)
+            self._status.checkout(commit_id=commit_id)
 
     def _commit(self, message: str, tag: Optional[str] = None) -> str:
         post_data: Dict[str, Any] = {


### PR DESCRIPTION
The `commit_id` in `DatasetClientBase.__init__` is always from
the `getDataset` request in `GAS.get_dataset`, which means the
validation of the `commit_id` is guaranteed by OpenAPI.