### PR TITLE
docs: get Segment instance from Dataset rather than DatasetClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,9 @@ dataset_client.commit("Initial commit")
 
 ```python
 from PIL import Image
-from tensorbay.dataset import Segment
 
-dataset_client = gas.get_dataset("DatasetName")
-
-segment = Segment("", dataset_client)
+dataset = Dataset("DatasetName", gas)
+segment = dataset[0]
 
 for data in segment:
     with data.open() as fp:

--- a/docs/source/examples/read_dataset_class.rst
+++ b/docs/source/examples/read_dataset_class.rst
@@ -53,7 +53,7 @@ TensorBay supplies two methods to fetch :ref:`reference/dataset_structure:Segmen
 
 .. literalinclude:: ../../../examples/BSTLD.py
    :language: python
-   :start-after: """Read Dataset Class / get a segment"""
+   :start-after: """Read Dataset / get segment"""
    :end-before: """"""
 
 This :ref:`reference/dataset_structure:Segment` is the same as the one :ref:`read from TensorBay <examples/BSTLD:Read Dataset>`.

--- a/examples/BSTLD.py
+++ b/examples/BSTLD.py
@@ -44,22 +44,16 @@ dataset_client.commit("initial commit")
 """"""
 
 """Read Dataset / get dataset"""
-dataset_client = gas.get_dataset("BSTLD")
+dataset = Dataset("BSTLD", gas)
 """"""
 
 """Read Dataset / list segment names"""
-dataset_client.list_segment_names()
-""""""
-
-"""Read Dataset Class / get a segment"""
-train_segment = dataset["train"]
-first_segment = dataset[0]
+dataset.keys()
 """"""
 
 """Read Dataset / get segment"""
-from tensorbay.dataset import Segment
-
-train_segment = Segment("train", dataset_client)
+first_segment = dataset[0]
+train_segment = dataset["train"]
 """"""
 
 """Read Dataset / get data"""

--- a/examples/CADC.py
+++ b/examples/CADC.py
@@ -15,6 +15,7 @@
 
 """Authorize a Client Instance"""
 from tensorbay import GAS
+from tensorbay.dataset import FusionDataset
 
 ACCESS_KEY = "Accesskey-*****"
 gas = GAS(ACCESS_KEY)
@@ -39,17 +40,15 @@ fusion_dataset_client.commit("initial commit")
 """"""
 
 """Read Fusion Dataset / get fusion dataset"""
-fusion_dataset_client = gas.get_dataset("CADC", is_fusion=True)
+fusion_dataset = FusionDataset("CADC", gas)
 """"""
 
 """Read Fusion Dataset / list fusion segment names"""
-fusion_dataset_client.list_segment_names()
+fusion_dataset.keys()
 """"""
 
 """Read Fusion Dataset / get fusion segment"""
-from tensorbay.dataset import FusionSegment
-
-fusion_segment = FusionSegment("2018_03_06/0001", fusion_dataset_client)
+fusion_segment = fusion_dataset["2018_03_06/0001"]
 """"""
 
 """Read Fusion Dataset / get sensors"""

--- a/examples/DogsVsCats.py
+++ b/examples/DogsVsCats.py
@@ -44,26 +44,19 @@ dataset_client.commit("initial commit")
 """"""
 
 """Read Dataset / get dataset"""
-dataset_client = gas.get_dataset("DogsVsCats")
+dataset = Dataset("DogsVsCats", gas)
 """"""
 
 """Read Dataset / list segment names"""
-dataset_client.list_segment_names()
-""""""
-
-"""Read Dataset Class / get a segment"""
-train_segment = dataset["train"]
-first_segment = dataset[0]
+dataset.keys()
 """"""
 
 """Read Dataset / get segment"""
-from tensorbay.dataset import Segment
-
-train_segment = Segment("train", dataset_client)
+segment = dataset["train"]
 """"""
 
 """Read Dataset / get data"""
-data = train_segment[0]
+data = segment[0]
 """"""
 
 """Read Dataset / get label"""

--- a/examples/LeedsSportsPose.py
+++ b/examples/LeedsSportsPose.py
@@ -45,17 +45,15 @@ dataset_client.commit("initial commit")
 """"""
 
 """Read Dataset / get dataset"""
-dataset_client = gas.get_dataset("LeedsSportsPose")
+dataset = Dataset("LeedsSportsPose", gas)
 """"""
 
 """Read Dataset / get segment"""
-from tensorbay.dataset import Segment
-
-default_segment = Segment("", dataset_client)
+segment = dataset[0]
 """"""
 
 """Read Dataset / get data"""
-data = default_segment[0]
+data = segment[0]
 """"""
 
 """Read Dataset / get label"""

--- a/examples/NeolixOD.py
+++ b/examples/NeolixOD.py
@@ -44,17 +44,15 @@ dataset_client.commit("initial commit")
 """"""
 
 """Read Dataset / get dataset"""
-dataset_client = gas.get_dataset("NeolixOD")
+dataset = Dataset("NeolixOD", gas)
 """"""
 
 """Read Dataset / get segment"""
-from tensorbay.dataset import Segment
-
-default_segment = Segment("", dataset_client)
+segment = dataset[0]
 """"""
 
 """Read Dataset / get data"""
-data = default_segment[0]
+data = segment[0]
 """"""
 
 """Read Dataset / get label"""

--- a/examples/Newsgroups20.py
+++ b/examples/Newsgroups20.py
@@ -44,21 +44,19 @@ dataset_client.commit("initial commit")
 """"""
 
 """Read Dataset / get dataset"""
-dataset_client = gas.get_dataset("Newsgroups20")
+dataset = Dataset("Newsgroups20", gas)
 """"""
 
 """Read Dataset / list segment names"""
-dataset_client.list_segment_names()
+dataset.keys()
 """"""
 
 """Read Dataset / get segment"""
-from tensorbay.dataset import Segment
-
-segment_20news_18828 = Segment("20news-18828", dataset_client)
+segment = dataset["20news-18828"]
 """"""
 
 """Read Dataset / get data"""
-data = segment_20news_18828[0]
+data = segment[0]
 """"""
 
 """Read Dataset / get label"""

--- a/examples/THCHS30.py
+++ b/examples/THCHS30.py
@@ -44,21 +44,19 @@ dataset_client.commit("initial commit")
 """"""
 
 """Read Dataset / get dataset"""
-dataset_client = gas.get_dataset("THCHS-30")
+dataset = Dataset("THCHS-30", gas)
 """"""
 
 """Read Dataset / list segment names"""
-dataset_client.list_segment_names()
+dataset.keys()
 """"""
 
 """Read Dataset / get segment"""
-from tensorbay.dataset import Segment
-
-dev_segment = Segment("dev", dataset_client)
+segment = dataset["dev"]
 """"""
 
 """Read Dataset / get data"""
-data = dev_segment[0]
+data = segment[0]
 """"""
 
 """Read Dataset / get label"""

--- a/examples/getting_started_with_tensorbay.py
+++ b/examples/getting_started_with_tensorbay.py
@@ -46,11 +46,9 @@ dataset_client.commit("Initial commit")
 
 """Read Images from the Dataset"""
 from PIL import Image
-from tensorbay.dataset import Segment
 
-dataset_client = gas.get_dataset("DatasetName")
-
-segment = Segment("", dataset_client)
+dataset = Dataset("DatasetName", gas)
+segment = dataset[0]
 
 for data in segment:
     with data.open() as fp:


### PR DESCRIPTION
`Dataset.__init__` is supported to get a lazy evaluated `Dataset`
It will be more pythonic to get a `Segment` instance from `Dataset`
rather than `DatasetClient`