### PR TITLE
perf(dataset): treat Segment init from client non-empty in ReprMixin

### DIFF
--- a/tensorbay/dataset/segment.py
+++ b/tensorbay/dataset/segment.py
@@ -66,6 +66,7 @@ class Segment(NameMixin, UserMutableSequence["DataBase._Type"]):
         if client:
             self._client = client.get_segment(name)
             self._data = self._client.list_data()  # type: ignore[assignment]
+            self._repr_non_empty = True
         else:
             self._data = []
 
@@ -84,6 +85,7 @@ class Segment(NameMixin, UserMutableSequence["DataBase._Type"]):
         segment = cls(client.name)
         segment._client = client
         segment._data = client.list_data()  # type: ignore[assignment]
+        segment._repr_non_empty = True
         return segment
 
     def sort(
@@ -159,6 +161,7 @@ class FusionSegment(NameMixin, UserMutableSequence[Frame]):
         if client:
             self._client = client.get_segment(name)
             self._data = self._client.list_frames()
+            self._repr_non_empty = True
         else:
             self._data = []
             self._sensors = Sensors()
@@ -179,6 +182,7 @@ class FusionSegment(NameMixin, UserMutableSequence[Frame]):
         super(cls, segment).__init__(client.name)
         segment._client = client
         segment._data = client.list_frames()
+        segment._repr_non_empty = True
         return segment
 
     @property

--- a/tensorbay/utility/repr.py
+++ b/tensorbay/utility/repr.py
@@ -35,6 +35,7 @@ class ReprMixin:  # pylint: disable=too-few-public-methods
     _repr_type = ReprType.INSTANCE
     _repr_attrs: Iterable[str] = ()
     _repr_maxlevel = 1
+    _repr_non_empty = False
 
     def __repr__(self) -> str:
         return _repr1(self, self._repr_maxlevel, self._repr_maxlevel, True)
@@ -248,6 +249,9 @@ def _repr_builtin_dict(obj: Mapping[Any, Any], level: int, maxlevel: int, foldin
         "repr" of the object.
 
     """
+    if getattr(obj, "_repr_non_empty", False) and level <= 0:
+        return "{...}"
+
     object_length = len(obj)
     if object_length == 0:
         return "{}"
@@ -321,6 +325,9 @@ def _repr_builtin_sequence(  # pylint: disable=too-many-arguments
         "repr" of the object.
 
     """
+    if getattr(obj, "_repr_non_empty", False) and level <= 0:
+        return f"{left}...{right}"
+
     object_length = len(obj)
     if object_length == 0:
         return f"{left}{right}"


### PR DESCRIPTION
Root Cause:
`ReprMixin.__repr__` will check `len(obj)` to print `[]` or `[...]`
But in `PagingList` lazy evaluation system, if the obj is not
initialized, `len(obj)` will send request for the totalCount, which may
cause a lot of requests just for print.

Workaround:
Add a flag `_repr_non_empty` to make `ReprMixin` skip checking
the `len(obj)` and always print `[...]`