### PR TITLE
fix(client): fix the TypeError when uploading dataset got interrupted

### DIFF
--- a/tensorbay/client/gas.py
+++ b/tensorbay/client/gas.py
@@ -408,8 +408,8 @@ class GAS:
         except Exception:
             logger.error(
                 UPLOAD_DATASET_RESUME_TEMPLATE,
-                draft_number,
-                draft_number,
+                dataset_client.status.draft_number,
+                dataset_client.status.draft_number,
             )
             raise
 


### PR DESCRIPTION
The method `gas.upload_dataset()` will log the resume error message when
the upload got interrupted.
But when `draft_number` parameter is not given,
the logging of resume error message will raise
`TypeError: %d format: a number is required, not NoneType`.