### PR TITLE
fix(client): fix the TypeError when put Dataset in multiprocess pool

### DIFF
--- a/tensorbay/client/requests.py
+++ b/tensorbay/client/requests.py
@@ -16,7 +16,6 @@ import os
 from collections import defaultdict
 from concurrent.futures import FIRST_EXCEPTION, ThreadPoolExecutor, wait
 from itertools import repeat, zip_longest
-from threading import Lock
 from typing import (
     Any,
     Callable,
@@ -457,7 +456,7 @@ class LazyPage(Generic[_T]):  # pylint: disable=too-few-public-methods
 
     """
 
-    __slots__ = ("_offset", "_limit", "_func", "_lock", "items")
+    __slots__ = ("_offset", "_limit", "_func", "items")
 
     def __init__(self, offset: int, limit: int, func: PagingGenerator[_T]) -> None:
         self.items: Tuple[LazyItem[_T], ...] = tuple(LazyItem.from_page(self) for _ in range(limit))
@@ -468,7 +467,6 @@ class LazyPage(Generic[_T]):  # pylint: disable=too-few-public-methods
         self._offset = offset
         self._limit = limit
         self._func = func
-        self._lock = Lock()
 
     @locked
     def pull(self) -> None:
@@ -533,7 +531,6 @@ class PagingList(MutableSequence[_T], ReprMixin):  # pylint: disable=too-many-an
     def __init__(self, func: PagingGenerator[_T], limit: int) -> None:
         self._func = func
         self._limit = limit
-        self._lock = Lock()
         self._init_items: Callable[[int], None] = self._init_all_items
 
     def __len__(self) -> int:

--- a/tensorbay/client/segment.py
+++ b/tensorbay/client/segment.py
@@ -24,7 +24,6 @@ for more information.
 """
 
 import os
-import threading
 import time
 from copy import deepcopy
 from itertools import islice
@@ -35,8 +34,9 @@ from requests_toolbelt import MultipartEncoder
 from ulid import from_timestamp
 
 from ..dataset import Data, Frame, RemoteData
-from ..exception import FrameError, InvalidParamsError, ResponseError, ResponseSystemError
+from ..exception import FrameError, InvalidParamsError, ResponseSystemError
 from ..sensor.sensor import Sensor, Sensors
+from ..utility import locked
 from .commit_status import CommitStatus
 from .requests import PagingList, config
 
@@ -78,7 +78,6 @@ class SegmentClientBase:  # pylint: disable=too-many-instance-attributes
         self._status = dataset_client.status
         self._client = dataset_client._client  # pylint: disable=protected-access
         self._permission: Dict[str, Any] = {"expireAt": 0}
-        self._permission_lock = threading.Lock()
 
     def _get_url(self, remote_path: str) -> str:
         """Get URL of a specific remote path.
@@ -113,27 +112,23 @@ class SegmentClientBase:  # pylint: disable=too-many-instance-attributes
         response = self._client.open_api_do("GET", "labels", self._dataset_id, params=params)
         return response.json()  # type: ignore[no-any-return]
 
+    @locked
+    def _request_upload_permission(self) -> None:
+        params: Dict[str, Any] = {"expired": self._EXPIRED_IN_SECOND, "segmentName": self._name}
+        params.update(self._status.get_status_info())
+
+        if config.is_internal:
+            params["isInternal"] = True
+
+        self._permission = self._client.open_api_do(
+            "GET", "policies", self._dataset_id, params=params
+        ).json()
+
     def _get_upload_permission(self) -> Dict[str, Any]:
-        with self._permission_lock:
-            if int(time.time()) >= self._permission["expireAt"]:
-                params: Dict[str, Any] = {
-                    "expired": self._EXPIRED_IN_SECOND,
-                    "segmentName": self._name,
-                }
-                params.update(self._status.get_status_info())
+        if int(time.time()) >= self._permission["expireAt"]:
+            self._request_upload_permission()
 
-                if config.is_internal:
-                    params["isInternal"] = True
-
-                self._permission = self._client.open_api_do(
-                    "GET", "policies", self._dataset_id, params=params
-                ).json()
-
-            return deepcopy(self._permission)
-
-    def _clear_upload_permission(self) -> None:
-        with self._permission_lock:
-            self._permission = {"expireAt": 0}
+        return deepcopy(self._permission)
 
     def _post_multipart_formdata(
         self,
@@ -299,7 +294,6 @@ class SegmentClient(SegmentClientBase):
 
         Raises:
             InvalidParamsError: When target_remote_path does not follow linux style.
-            ResponseError: When uploading data failed.
 
         """
         self._status.check_authority_for_draft()
@@ -314,28 +308,23 @@ class SegmentClient(SegmentClientBase):
         post_data = permission["result"]
         post_data["key"] = permission["extra"]["objectPrefix"] + target_remote_path
 
-        try:
-            backend_type = permission["extra"]["backendType"]
-            if backend_type == "azure":
-                url = (
-                    f'{permission["extra"]["host"]}{permission["extra"]["objectPrefix"]}'
-                    f'{target_remote_path}?{permission["result"]["token"]}'
-                )
+        backend_type = permission["extra"]["backendType"]
+        if backend_type == "azure":
+            url = (
+                f'{permission["extra"]["host"]}{permission["extra"]["objectPrefix"]}'
+                f'{target_remote_path}?{permission["result"]["token"]}'
+            )
 
-                version_id, etag = self._put_binary_file_to_azure(url, local_path, post_data)
-            else:
-                version_id, etag = self._post_multipart_formdata(
-                    permission["extra"]["host"],
-                    local_path,
-                    target_remote_path,
-                    post_data,
-                )
+            version_id, etag = self._put_binary_file_to_azure(url, local_path, post_data)
+        else:
+            version_id, etag = self._post_multipart_formdata(
+                permission["extra"]["host"],
+                local_path,
+                target_remote_path,
+                post_data,
+            )
 
-            self._synchronize_upload_info(post_data["key"], version_id, etag)
-
-        except ResponseError:
-            self._clear_upload_permission()
-            raise
+        self._synchronize_upload_info(post_data["key"], version_id, etag)
 
     def upload_label(self, data: Data) -> None:
         """Upload label with Data object to the draft.
@@ -467,7 +456,6 @@ class FusionSegmentClient(SegmentClientBase):
         Raises:
             FrameError: When lacking frame id or frame id conflicts.
             InvalidParamsError: When remote_path does not follow linux style.
-            ResponseError: When uploading frame failed.
 
         """
         self._status.check_authority_for_draft()
@@ -498,38 +486,34 @@ class FusionSegmentClient(SegmentClientBase):
             post_data = permission["result"]
             post_data["key"] = permission["extra"]["objectPrefix"] + target_remote_path
 
-            try:
-                backend_type = permission["extra"]["backendType"]
-                if backend_type == "azure":
-                    url = (
-                        f'{permission["extra"]["host"]}{permission["extra"]["objectPrefix"]}'
-                        f'{target_remote_path}?{permission["result"]["token"]}'
-                    )
-
-                    version_id, etag = self._put_binary_file_to_azure(url, data.path, post_data)
-                else:
-                    version_id, etag = self._post_multipart_formdata(
-                        permission["extra"]["host"],
-                        data.path,
-                        target_remote_path,
-                        post_data,
-                    )
-
-                frame_info: Dict[str, Any] = {
-                    "segmentName": self._name,
-                    "sensorName": sensor_name,
-                    "frameId": str(frame_id),
-                }
-                if hasattr(data, "timestamp"):
-                    frame_info["timestamp"] = data.timestamp
-
-                self._synchronize_upload_info(
-                    post_data["key"], version_id, etag, frame_info, skip_uploaded_files
+            backend_type = permission["extra"]["backendType"]
+            if backend_type == "azure":
+                url = (
+                    f'{permission["extra"]["host"]}{permission["extra"]["objectPrefix"]}'
+                    f'{target_remote_path}?{permission["result"]["token"]}'
                 )
 
-            except ResponseError:
-                self._clear_upload_permission()
-                raise
+                version_id, etag = self._put_binary_file_to_azure(url, data.path, post_data)
+            else:
+                version_id, etag = self._post_multipart_formdata(
+                    permission["extra"]["host"],
+                    data.path,
+                    target_remote_path,
+                    post_data,
+                )
+
+            frame_info: Dict[str, Any] = {
+                "segmentName": self._name,
+                "sensorName": sensor_name,
+                "frameId": str(frame_id),
+            }
+            if hasattr(data, "timestamp"):
+                frame_info["timestamp"] = data.timestamp
+
+            self._synchronize_upload_info(
+                post_data["key"], version_id, etag, frame_info, skip_uploaded_files
+            )
+
             self._upload_label(data)
 
     def list_frames(self) -> PagingList[Frame]:

--- a/tensorbay/dataset/dataset.py
+++ b/tensorbay/dataset/dataset.py
@@ -23,7 +23,6 @@ It consists of a list of :class:`~tensorbay.dataset.segment.FusionSegment`.
 """
 
 import json
-from threading import Lock
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -166,7 +165,6 @@ class DatasetBase(NameMixin, Sequence[_T]):  # pylint: disable=too-many-ancestor
         self, name: str, gas: Optional["GAS"] = None, revision: Optional[str] = None
     ) -> None:
         super().__init__(name)
-        self._lock = Lock()
 
         if gas:
             self._client = gas.get_dataset(name, is_fusion=self._is_fusion)


### PR DESCRIPTION
Root Cause:
The `threading.Lock` object cannot be pickled. The `threading.Lock` is
widely used in `Dataset` to avoid sending redundant requests. So that
putting `Dataset` in multiprocess pool will hit the TypeError caused by
`threading.Lock`:
```python
TypeError: cannot pickle '_thread.lock' object
```

Solution:
Remove all the `theading.Lock` member in `Dataset`, and use a lock pool
to dynamicly create `threading.Lock` when sending request.