### PR TITLE
fix(cli): adjust docstring and echo message in 5 files

### DIFF
--- a/tensorbay/cli/cli.py
+++ b/tensorbay/cli/cli.py
@@ -144,6 +144,7 @@ def dataset(obj: Dict[str, str], name: str, is_delete: bool, yes: bool) -> None:
         name: The name of the dataset to be created or the tbrn of dataset to be deleted.
         is_delete: Whether to delete the TensorBay dataset.
         yes: Confirm to delete the dataset completely.
+
     """  # noqa: D301,D415
     from .dataset import _implement_dataset
 
@@ -161,7 +162,7 @@ def draft(
     is_list: bool,
     title: str,
 ) -> None:
-    """Work with draft.
+    """Work with draft.\f
 
     Arguments:
         obj: A dict contains config information.
@@ -180,7 +181,7 @@ def draft(
 @click.option("-m", "--message", type=str, required=True, help="The message of the commit.")
 @click.pass_obj
 def commit(obj: Dict[str, str], tbrn: str, message: str) -> None:
-    """Work with commit.
+    """Work with commit.\f
 
     Arguments:
         obj: A dict contains config information.
@@ -216,7 +217,7 @@ def cp(  # pylint: disable=invalid-name, too-many-arguments
     jobs: int,
     skip_uploaded_files: bool,
 ) -> None:
-    """Copy local data to a remote path.
+    """Copy local data to a remote path.\f
 
     Arguments:
         obj: A dict contains config information.
@@ -241,7 +242,7 @@ def cp(  # pylint: disable=invalid-name, too-many-arguments
 def rm(  # pylint: disable=invalid-name, too-many-arguments
     obj: Dict[str, str], tbrn: str, is_recursive: bool
 ) -> None:
-    """Remove the remote data.
+    """Remove the remote data.\f
 
     Arguments:
         obj: A dict contains config information.

--- a/tensorbay/cli/commit.py
+++ b/tensorbay/cli/commit.py
@@ -24,7 +24,7 @@ def _implement_commit(obj: Dict[str, str], tbrn: str, message: str) -> None:
         sys.exit(1)
 
     if not info.is_draft:
-        click.echo(f'To commit, "{info}" must be in draft status, like "{info}#1', err=True)
+        click.echo(f'To commit, "{info}" must be in draft status, like "{info}#1"', err=True)
         sys.exit(1)
 
     dataset_client.checkout(draft_number=info.draft_number)

--- a/tensorbay/cli/draft.py
+++ b/tensorbay/cli/draft.py
@@ -38,7 +38,7 @@ def _create_draft(dataset_client: DatasetClientType, info: TBRN, title: str) -> 
         sys.exit(1)
 
     if info.revision:
-        click.echo(f'Create a draft based on given revision "{info}" is not supported"', err=True)
+        click.echo(f'Create a draft based on given revision "{info}" is not supported', err=True)
         sys.exit(1)
 
     dataset_client.create_draft(title=title)

--- a/tensorbay/cli/rm.py
+++ b/tensorbay/cli/rm.py
@@ -25,7 +25,7 @@ def _implement_rm(obj: Dict[str, str], tbrn: str, is_recursive: bool) -> None:
 
     if not info.is_draft:
         click.echo(
-            f'To remove the data, "{info}" must be in draft status, like "{info}#1', err=True
+            f'To remove the data, "{info}" must be in draft status, like "{info}#1"', err=True
         )
         sys.exit(1)
 

--- a/tensorbay/cli/utility.py
+++ b/tensorbay/cli/utility.py
@@ -90,7 +90,7 @@ def get_gas(access_key: str, url: str, profile_name: str) -> GAS:
         access_key, url = read_config(get_config_filepath(), profile_name)
 
     if not access_key:
-        click.echo("accessKey should be appointed", err=True)
+        click.echo("AccessKey should be appointed", err=True)
         sys.exit(1)
 
     return GAS(access_key, url)
@@ -121,7 +121,7 @@ def get_dataset_client(gas: GAS, info: TBRN, is_fusion: Optional[bool] = None) -
 
     Arguments:
         gas: The gas client.
-        info: The tbrn of the resource
+        info: The tbrn of the resource.
         is_fusion: Whether the dataset is a fusion dataset, True for fusion dataset.
 
     Returns:


### PR DESCRIPTION
1. Add "\f" at the end of introduction of function in cli.py.
2. Adjust double quotes in echo message in commit.py, rm.py and draft.py.
3. Add missing period in utility.py.
4. Capitalize the first character in echo message in utility.py