### PR TITLE
fix(client): fix JSONDecodeError when failed response not from OpenAPI

### DIFF
--- a/tensorbay/exception.py
+++ b/tensorbay/exception.py
@@ -120,7 +120,7 @@ class ResponseError(ClientError):
     def __str__(self) -> str:
         return (
             f"Unexpected status code({self.response.status_code})! {self.response.url}!"
-            f"\n{self._INDENT}  {self.response.json()['message']}"
+            f"\n{self._INDENT}  {self.response.text}"
         )
 
 


### PR DESCRIPTION
Root Cause:

When the status code of a response is unexpected, the custom
`ResponseError` would be raised.

`ResponseError` would use `response.json()` to get the content of the
failed response.

If the failed response is not from OpenAPI, the "Content-Type" may not
be "application/json" which causes `JSONDecodeError` when executing
`response.json()`.

Solution:

- Use `response.text` instead of `response.json()` to get the
response content in `ResponseError`.
- Only use `response.json()` to get the error code in `Client.open_api_do()`.

Issue Closed: https://github.com/Graviti-AI/tensorbay-python-sdk/issues/562