### PR TITLE
fix(cli): fix ImportError when executing gas CLI in python3.6 and 3.7

### DIFF
--- a/tensorbay/cli/utility.py
+++ b/tensorbay/cli/utility.py
@@ -9,9 +9,10 @@ import logging
 import os
 import sys
 from configparser import ConfigParser
-from typing import Iterable, Iterator, Literal, Optional, Tuple, overload
+from typing import Iterable, Iterator, Optional, Tuple, overload
 
 import click
+from typing_extensions import Literal
 
 from ..client import GAS
 from ..client import config as client_config


### PR DESCRIPTION
Root Cause:
`tensorbay/cli/utility.py` import `Literal` from `typing`, but `Literal`
is added to `typing` in python3.8, which causes the `ImportError`:
```python
ImportError: cannot import name 'Literal'
```

Solution:
Import `Literal` from `typing_extensions`