### PR TITLE
docs: shorten titles of docs under integrations.rst

### DIFF
--- a/docs/source/integrations/pytorch.rst
+++ b/docs/source/integrations/pytorch.rst
@@ -1,6 +1,6 @@
-##################################
- Integrate TensorBay with PyTorch
-##################################
+#########
+ PyTorch
+#########
 
 This topic describes how to integrate TensorBay dataset with PyTorch Pipeline
 using the `MNIST Dataset <https://gas.graviti.cn/dataset/data-decorators/MNIST>`_ as an example.

--- a/docs/source/integrations/tensorflow.rst
+++ b/docs/source/integrations/tensorflow.rst
@@ -1,6 +1,6 @@
 :orphan:
 :nosearch:
 
-#####################################
- Integrate TensorBay with TensorFlow
-#####################################
+############
+ TensorFlow
+############


### PR DESCRIPTION
"Integrate TensorBay with TensorFlow" -> "TensorFlow"
"Integrate TensorBay with PyTorch" -> "PyTorch"