### PR TITLE
refactor(utility): use "AttrsMixin" in "NameMixin"

### DIFF
--- a/tensorbay/dataset/dataset.py
+++ b/tensorbay/dataset/dataset.py
@@ -137,7 +137,9 @@ class Notes(ReprMixin, EqMixin):
         return contents
 
 
-class DatasetBase(NameMixin, Sequence[_T]):  # pylint: disable=too-many-ancestors
+# When the NameMixin is before Sequence[_T], typing will raise AttributeError.
+# related issue: python/typing#777
+class DatasetBase(Sequence[_T], NameMixin):  # pylint: disable=too-many-ancestors
     """This class defines the concept of a basic dataset.
 
     DatasetBase represents a whole dataset contains several segments

--- a/tensorbay/utility/name.py
+++ b/tensorbay/utility/name.py
@@ -23,12 +23,13 @@ from typing import Dict, Iterator, List, Mapping, Optional, Sequence, Type, Type
 
 from sortedcontainers import SortedDict
 
-from ..utility import EqMixin, common_loads
+from .attr import AttrsMixin, attr
+from .common import common_loads
 from .repr import ReprMixin
 from .user import UserMapping
 
 
-class NameMixin(ReprMixin, EqMixin):
+class NameMixin(ReprMixin, AttrsMixin):
     """A mixin class for instance which has immutable name and mutable description.
 
     Arguments:
@@ -42,6 +43,9 @@ class NameMixin(ReprMixin, EqMixin):
 
     _P = TypeVar("_P", bound="NameMixin")
 
+    _name: str = attr(key="name")
+    description: str = attr(default="")
+
     def __init__(self, name: str, description: str = "") -> None:
         self._name = name
         self.description = description
@@ -49,11 +53,7 @@ class NameMixin(ReprMixin, EqMixin):
     def _repr_head(self) -> str:
         return f'{self.__class__.__name__}("{self._name}")'
 
-    def _loads(self, contents: Dict[str, str]) -> None:
-        self._name = contents["name"]
-        self.description = contents.get("description", "")
-
-    def _dumps(self) -> Dict[str, str]:
+    def dumps(self) -> Dict[str, str]:
         """Dumps the instance into a dict.
 
         Returns:
@@ -66,11 +66,7 @@ class NameMixin(ReprMixin, EqMixin):
                 }
 
         """
-        contents = {"name": self._name}
-        if self.description:
-            contents["description"] = self.description
-
-        return contents
+        return self._dumps()
 
     @classmethod
     def loads(cls: Type[_P], contents: Dict[str, str]) -> _P:


### PR DESCRIPTION
`DatasetBase` inherits from classes `Sequence[_T]` and `NameMixin`,
When the `NameMixin` is before `Sequence[_T]`, `typing` will raise
`AttributeError`.

related issue : https://github.com/python/typing/issues/777