### PR TITLE
fix(utility): fix ValueError passing the last item to UserSequence.index

### DIFF
--- a/tensorbay/utility/user.py
+++ b/tensorbay/utility/user.py
@@ -15,6 +15,7 @@
 
 """
 
+from sys import maxsize
 from typing import (
     AbstractSet,
     Any,
@@ -63,7 +64,7 @@ class UserSequence(Sequence[_T], ReprMixin):  # pylint: disable=too-many-ancesto
     def __iter__(self) -> Iterator[_T]:
         return self._data.__iter__()
 
-    def index(self, value: _T, start: int = 0, stop: int = -1) -> int:
+    def index(self, value: _T, start: int = 0, stop: int = maxsize) -> int:
         """Return the first index of the value.
 
         Arguments:


### PR DESCRIPTION
Root Cause:
The default value of `stop` argument is `-1`, which will skip the last
item when checking the index.

Solution:
Change the default value of `stop` to `maxsize`

Issue Closed: https://github.com/Graviti-AI/tensorbay-python-sdk/issues/610