### PR TITLE
perf(geometry): stop using numpy array in "uniform_frechet_distance"

### DIFF
--- a/tensorbay/geometry/tests/test_polyline.py
+++ b/tensorbay/geometry/tests/test_polyline.py
@@ -3,46 +3,58 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 
-from itertools import zip_longest
-
-import numpy as np
-import pytest
+from math import isclose
 
 from .. import Box2D, Polyline2D, Vector2D
 
-_POLYLINE_INFO_1 = [
+_POLYLINE_SEQUENCE_1 = [[1, 1], [2, 2], [4, 4], [5, 5]]
+_POLYLINE_SEQUENCE_2 = [[2, 1], [4, 3], [6, 5]]
+
+_POLYLINE_1 = Polyline2D(_POLYLINE_SEQUENCE_1)
+_POLYLINE_2 = Polyline2D(_POLYLINE_SEQUENCE_2)
+
+_POLYLINE_INFO_1 = (
     {
-        "vector": np.array([0, 1], dtype=np.float32),
-        "last_time": 0,
-        "time": 0.5,
-        "point": np.array([1, 1], dtype=np.float32),
         "index": 0,
-    },
-    {
-        "vector": np.array([1, 0], dtype=np.float32),
-        "last_time": 0.5,
-        "time": 1.0,
-        "point": np.array([1, 2], dtype=np.float32),
-        "index": 1,
-    },
-]
-_POLYLINE_INFO_2 = [
-    {
-        "vector": np.array([-9, 12], dtype=np.float32),
+        "point": Vector2D(1, 1),
+        "vector": Vector2D(1, 1),
+        "time": 0.25,
         "last_time": 0,
+    },
+    {
+        "index": 1,
+        "point": Vector2D(2, 2),
+        "vector": Vector2D(2, 2),
         "time": 0.75,
-        "point": np.array([10, -9], dtype=np.float32),
-        "index": 0,
+        "last_time": 0.25,
     },
     {
-        "vector": np.array([3, 4], dtype=np.float32),
-        "last_time": 0.75,
+        "index": 2,
+        "point": Vector2D(4, 4),
+        "vector": Vector2D(1, 1),
         "time": 1.0,
-        "point": np.array([1, 3], dtype=np.float32),
-        "index": 1,
+        "last_time": 0.75,
     },
-]
-_POLYLINE_DATA = [{"x": 1, "y": 1}, {"x": 1, "y": 2}, {"x": 2, "y": 2}]
+)
+_POLYLINE_INFO_2 = (
+    {
+        "index": 0,
+        "point": Vector2D(2, 1),
+        "vector": Vector2D(2, 2),
+        "time": 0.5,
+        "last_time": 0,
+    },
+    {
+        "index": 1,
+        "point": Vector2D(4, 3),
+        "vector": Vector2D(2, 2),
+        "time": 1.0,
+        "last_time": 0.5,
+    },
+)
+
+_POLYLINE_CONTENT_1 = [{"x": 1, "y": 1}, {"x": 2, "y": 2}, {"x": 4, "y": 4}, {"x": 5, "y": 5}]
+_POLYLINE_CONTENT_2 = [{"x": 2, "y": 1}, {"x": 4, "y": 3}, {"x": 6, "y": 5}]
 
 
 class TestPolyline2D:
@@ -58,67 +70,42 @@ class TestPolyline2D:
         assert (polyline_1 == polyline_2) == True
         assert (polyline_1 == polyline_3) == False
 
-    def test_distance(self):
-        sequence_1 = [1, 2]
-        sequence_2 = [4, 6]
-        assert Polyline2D._distance(sequence_1, sequence_2) == 5.0
-
     def test_get_polyline_info(self):
-        sequence = [[1, 1], [1, 2], [2, 2]]
-        polyline_info = Polyline2D._get_polyline_info(sequence)
+        assert _POLYLINE_INFO_1 == Polyline2D._get_polyline_info(_POLYLINE_1)
+        assert _POLYLINE_INFO_2 == Polyline2D._get_polyline_info(_POLYLINE_2)
 
-        for info1, info2 in zip_longest(polyline_info, _POLYLINE_INFO_1):
-            assert info1["last_time"] == info2["last_time"]
-            assert info1["time"] == info2["time"]
-            assert info1["index"] == info2["index"]
-            np.testing.assert_array_equal(info1["vector"], info2["vector"])
-            np.testing.assert_array_equal(info1["point"], info2["point"])
+    def test_get_insert_arg(self):
+        assert Polyline2D._get_insert_arg(0.2, _POLYLINE_INFO_1[0]) == (1, Vector2D(1.8, 1.8))
+        assert Polyline2D._get_insert_arg(0.8, _POLYLINE_INFO_1[1]) == (2, Vector2D(4.2, 4.2))
 
-    def test_insert_point(self):
-        inserted_point = Polyline2D._insert_point(_POLYLINE_INFO_1[0], _POLYLINE_INFO_2[0])
-        assert inserted_point["index"] == 1
-        np.testing.assert_array_equal(inserted_point["point"], np.array([4, -1]))
-
-    def test_insert_points(self):
-        info1 = iter(_POLYLINE_INFO_1)
-        info2 = iter(_POLYLINE_INFO_2)
-        inserted_points_1 = Polyline2D._insert_points(info1, info2)
-        inserted_points_2 = (
-            [{"index": 2, "point": np.array([1.5, 2.0])}],
-            [{"index": 1, "point": np.array([4.0, -1.0])}],
+    def test_get_insert_args(self):
+        assert Polyline2D._get_insert_args(_POLYLINE_INFO_1, _POLYLINE_INFO_2) == (
+            [(2, Vector2D(3.0, 3.0))],
+            [(1, Vector2D(3.0, 2.0)), (2, Vector2D(5.0, 4.0))],
         )
-        for points_1, points_2 in zip_longest(inserted_points_1, inserted_points_2):
-            for point_1, point_2 in zip_longest(points_1, points_2):
-                assert point_1["index"] == point_2["index"]
-                np.testing.assert_array_equal(point_1["point"], point_2["point"])
-
-    def test_max_distance_in_point_pairs(self):
-        polyline_1 = np.array([[1, 1], [1, 2], [2, 2]])
-        polyline_2 = np.array([[4, 5], [2, 1], [3, 3]])
-        polyline_3 = np.array([[4, 5], [2, 1]])
-
-        with pytest.raises(AssertionError):
-            Polyline2D._max_distance_in_point_pairs(polyline_1, polyline_3)
-        assert Polyline2D._max_distance_in_point_pairs(polyline_1, polyline_2) == 5.0
 
     def test_uniform_frechet_distance(self):
-        polyline_1 = [[1, 1], [1, 2], [2, 2]]
-        polyline_2 = [[4, 5], [2, 1], [3, 3]]
-        assert Polyline2D.uniform_frechet_distance(polyline_1, polyline_2) == 3.605551275463989
+        assert Polyline2D.uniform_frechet_distance(_POLYLINE_1, _POLYLINE_1) == 0
+        assert Polyline2D.uniform_frechet_distance(_POLYLINE_2, _POLYLINE_2) == 0
+        assert Polyline2D.uniform_frechet_distance(_POLYLINE_1, _POLYLINE_2) == 1
+        assert Polyline2D.uniform_frechet_distance(_POLYLINE_SEQUENCE_1, _POLYLINE_SEQUENCE_2) == 1
 
     def test_similarity(self):
-        polyline_1 = [[1, 1], [1, 2], [2, 2]]
-        polyline_2 = [[4, 5], [2, 1], [3, 3]]
-        assert Polyline2D.similarity(polyline_1, polyline_2) == 0.2788897449072022
+        assert Polyline2D.similarity(_POLYLINE_1, _POLYLINE_1) == 1
+        assert Polyline2D.similarity(_POLYLINE_2, _POLYLINE_2) == 1
+        assert isclose(Polyline2D.similarity(_POLYLINE_1, _POLYLINE_2), 0.8438262381113939)
+        assert isclose(
+            Polyline2D.similarity(_POLYLINE_SEQUENCE_1, _POLYLINE_SEQUENCE_2), 0.8438262381113939
+        )
 
     def test_loads(self):
-        polyline = Polyline2D.loads(_POLYLINE_DATA)
-        assert polyline == Polyline2D([Vector2D(1, 1), Vector2D(1, 2), Vector2D(2, 2)])
+        assert Polyline2D.loads(_POLYLINE_CONTENT_1) == _POLYLINE_1
+        assert Polyline2D.loads(_POLYLINE_CONTENT_2) == _POLYLINE_2
 
     def test_dumps(self):
-        polyline = Polyline2D([[1, 1], [1, 2], [2, 2]])
-        assert polyline.dumps() == _POLYLINE_DATA
+        assert _POLYLINE_1.dumps() == _POLYLINE_CONTENT_1
+        assert _POLYLINE_2.dumps() == _POLYLINE_CONTENT_2
 
     def test_bounds(self):
-        polyline = Polyline2D([[1, 1], [1, 2], [2, 2]])
-        assert polyline.bounds() == Box2D(1, 1, 2, 2)
+        assert _POLYLINE_1.bounds() == Box2D(1, 1, 5, 5)
+        assert _POLYLINE_2.bounds() == Box2D(2, 1, 6, 5)


### PR DESCRIPTION
Modifications:
1. Stop using the numpy array.
2. Use `math.dist` to calculate the distance of two vector.
3. Use `tuple` instead of `list` when possible.
4. Use more generator and iterator.
5. Simply the calculation logic.

Target: enhance the performance of the following methods:
- `Polyline2D.uniform_frechet_distance`
- `Polyline2D.similarity`

Results:
```python
polyline_1 = [[1, 1], [1, 2], [2, 2]]
polyline_2 = [[4, 5], [2, 1], [3, 3]]
```

- before:
```python
>>> %timeit Polyline2D.uniform_frechet_distance(polyline_1, polyline_2)
231 µs ± 2.77 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)

>>> %timeit Polyline2D.similarity(polyline_1, polyline_2)
239 µs ± 3.36 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)
```

- after:
```python
>>> %timeit Polyline2D.uniform_frechet_distance(polyline_1, polyline_2)
59.1 µs ± 859 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)

>>> %timeit Polyline2D.similarity(polyline_1, polyline_2)
61 µs ± 380 ns per loop (mean ± std. dev. of 7 runs, 10000 loops each)
```