### PR TITLE
fix(dataset): fix UnicodeEncodeError when urlopen with chinese character

### DIFF
--- a/tensorbay/dataset/data.py
+++ b/tensorbay/dataset/data.py
@@ -12,7 +12,9 @@ It contains path information of a data sample and its corresponding labels.
 
 import os
 from http.client import HTTPResponse
+from string import printable
 from typing import Any, Callable, Dict, Optional, Type, TypeVar, Union
+from urllib.parse import quote
 from urllib.request import urlopen
 
 from _io import BufferedReader
@@ -292,7 +294,7 @@ class RemoteData(DataBase):
             The remote file pointer for this data.
 
         """
-        return urlopen(self.get_url())  # type: ignore[no-any-return]
+        return urlopen(quote(self.get_url(), safe=printable))  # type: ignore[no-any-return]
 
     def dumps(self) -> Dict[str, Any]:
         """Dumps the remote data into a dict.


### PR DESCRIPTION
Root Cause:
When opening the url containing chinese character, `UnicodeEncodeError`
will be raised, because `urlopen` only handle with url containing ASCII
code.

Solution:
Here using `urllib.parse.quote` to convert the chinese character.

Issue Closed: https://github.com/Graviti-AI/tensorbay-python-sdk/issues/676