### PR TITLE
refactor(client): use "allowed_methods" instead of "method_whitelist"

### DIFF
--- a/tensorbay/client/requests.py
+++ b/tensorbay/client/requests.py
@@ -112,7 +112,7 @@ class UserSession(Session):  # pylint: disable=too-few-public-methods
         retry_strategy = Retry(
             total=config.max_retries,
             status_forcelist=config.allowed_retry_status,
-            method_whitelist=config.allowed_retry_methods,
+            allowed_methods=config.allowed_retry_methods,
             raise_on_status=False,
         )
 


### PR DESCRIPTION
Deprecation warning from requests:
```
DeprecationWarning: Using 'method_whitelist' with Retry is deprecated
and will be removed in v2.0. Use 'allowed_methods' instead
```