### PR TITLE
feat(client): remove "strategy" argument in "move_data" method

### DIFF
--- a/tensorbay/client/segment.py
+++ b/tensorbay/client/segment.py
@@ -485,7 +485,6 @@ class SegmentClient(SegmentClientBase):
         target_remote_paths: Union[None, str, Iterable[str]] = None,
         *,
         source_client: Optional["SegmentClient"] = None,
-        strategy: str = "abort",
     ) -> None:
         """Move data to this segment, also used to rename data.
 
@@ -498,14 +497,8 @@ class SegmentClient(SegmentClientBase):
                 This argument is used to specifies where the moved data comes from when the moved
                 data is from another segment.
                 If None, the moved data comes from this segment.
-            strategy: The strategy of handling the name conflict. There are three options:
-
-                1. "abort": stop moving and raise exception;
-                2. "override": the source data will override the origin data;
-                3. "skip": keep the origin data.
 
         Raises:
-            InvalidParamsError: When strategy is invalid.
             OperationError: When the type or the length of target_remote_paths is not equal
                 with source_remote_paths.
                 Or when the dataset_id and drafter_number of source_client
@@ -513,9 +506,6 @@ class SegmentClient(SegmentClientBase):
 
         """
         self._status.check_authority_for_draft()
-
-        if strategy not in _STRATEGIES:
-            raise InvalidParamsError(param_name="strategy", param_value=strategy)
 
         if not target_remote_paths:
             all_target_remote_paths = []
@@ -560,7 +550,6 @@ class SegmentClient(SegmentClientBase):
             source["segmentName"] = self.name
 
         post_data: Dict[str, Any] = {
-            "strategy": strategy,
             "source": source,
             "segmentName": self.name,
         }

--- a/tests/test_move_and_copy.py
+++ b/tests/test_move_and_copy.py
@@ -266,8 +266,8 @@ class TestMove:
         segment_client.move_data("hello0.txt", "goodbye0.txt")
         segment_client.move_data("hello9.txt", "goodbye1.txt")
 
-        with pytest.raises(InvalidParamsError):
-            segment_client.move_data("hello1.txt", "goodbye2.txt", strategy="push")
+        # with pytest.raises(InvalidParamsError):
+        #     segment_client.move_data("hello1.txt", "goodbye2.txt", strategy="push")
         segment2 = Segment("Segment1", client=dataset_client)
         assert segment2[0].path == "goodbye0.txt"
         assert segment2[1].path == "goodbye1.txt"
@@ -276,66 +276,66 @@ class TestMove:
 
         gas_client.delete_dataset(dataset_name)
 
-    @pytest.mark.xfail(__version__ < "1.9.0", reason="not supported until 1.9.0")
-    def test_move_data_override(self, accesskey, url, tmp_path):
-        gas_client = GAS(access_key=accesskey, url=url)
-        dataset_name = get_dataset_name()
-        gas_client.create_dataset(dataset_name)
-        dataset = Dataset(name=dataset_name)
-        segment = dataset.create_segment("Segment1")
-        dataset._catalog = Catalog.loads(CATALOG)
-        path = tmp_path / "sub"
-        path.mkdir()
-        for i in range(10):
-            local_path = path / f"hello{i}.txt"
-            local_path.write_text(f"CONTENT_{i}")
-            data = Data(local_path=str(local_path))
-            data.label = Label.loads(LABEL)
-            segment.append(data)
+    # @pytest.mark.xfail(__version__ < "1.9.0", reason="not supported until 1.9.0")
+    # def test_move_data_override(self, accesskey, url, tmp_path):
+    #     gas_client = GAS(access_key=accesskey, url=url)
+    #     dataset_name = get_dataset_name()
+    #     gas_client.create_dataset(dataset_name)
+    #     dataset = Dataset(name=dataset_name)
+    #     segment = dataset.create_segment("Segment1")
+    #     dataset._catalog = Catalog.loads(CATALOG)
+    #     path = tmp_path / "sub"
+    #     path.mkdir()
+    #     for i in range(10):
+    #         local_path = path / f"hello{i}.txt"
+    #         local_path.write_text(f"CONTENT_{i}")
+    #         data = Data(local_path=str(local_path))
+    #         data.label = Label.loads(LABEL)
+    #         segment.append(data)
 
-        dataset_client = gas_client.upload_dataset(dataset)
-        segment_client = dataset_client.get_segment("Segment1")
+    #     dataset_client = gas_client.upload_dataset(dataset)
+    #     segment_client = dataset_client.get_segment("Segment1")
 
-        segment_client.move_data("hello0.txt", "hello1.txt", strategy="override")
+    #     segment_client.move_data("hello0.txt", "hello1.txt", strategy="override")
 
-        segment_moved = Segment("Segment1", client=dataset_client)
-        for data in segment_moved:
-            assert data.path != "hello0.txt"
-            assert data.label
-            if data.path == "hello1.txt":
-                assert data.open().read() == b"CONTENT_0"
+    #     segment_moved = Segment("Segment1", client=dataset_client)
+    #     for data in segment_moved:
+    #         assert data.path != "hello0.txt"
+    #         assert data.label
+    #         if data.path == "hello1.txt":
+    #             assert data.open().read() == b"CONTENT_0"
 
-        gas_client.delete_dataset(dataset_name)
+    #     gas_client.delete_dataset(dataset_name)
 
-    @pytest.mark.xfail(__version__ < "1.9.0", reason="not supported until 1.9.0")
-    def test_move_data_skip(self, accesskey, url, tmp_path):
-        gas_client = GAS(access_key=accesskey, url=url)
-        dataset_name = get_dataset_name()
-        gas_client.create_dataset(dataset_name)
-        dataset = Dataset(name=dataset_name)
-        segment = dataset.create_segment("Segment1")
-        dataset._catalog = Catalog.loads(CATALOG)
-        path = tmp_path / "sub"
-        path.mkdir()
-        for i in range(10):
-            local_path = path / f"hello{i}.txt"
-            local_path.write_text(f"CONTENT_{i}")
-            data = Data(local_path=str(local_path))
-            data.label = Label.loads(LABEL)
-            segment.append(data)
+    # @pytest.mark.xfail(__version__ < "1.9.0", reason="not supported until 1.9.0")
+    # def test_move_data_skip(self, accesskey, url, tmp_path):
+    #     gas_client = GAS(access_key=accesskey, url=url)
+    #     dataset_name = get_dataset_name()
+    #     gas_client.create_dataset(dataset_name)
+    #     dataset = Dataset(name=dataset_name)
+    #     segment = dataset.create_segment("Segment1")
+    #     dataset._catalog = Catalog.loads(CATALOG)
+    #     path = tmp_path / "sub"
+    #     path.mkdir()
+    #     for i in range(10):
+    #         local_path = path / f"hello{i}.txt"
+    #         local_path.write_text(f"CONTENT_{i}")
+    #         data = Data(local_path=str(local_path))
+    #         data.label = Label.loads(LABEL)
+    #         segment.append(data)
 
-        dataset_client = gas_client.upload_dataset(dataset)
-        segment_client = dataset_client.get_segment("Segment1")
+    #     dataset_client = gas_client.upload_dataset(dataset)
+    #     segment_client = dataset_client.get_segment("Segment1")
 
-        segment_client.move_data("hello0.txt", "hello1.txt", strategy="skip")
+    #     segment_client.move_data("hello0.txt", "hello1.txt", strategy="skip")
 
-        segment_moved = Segment("Segment1", client=dataset_client)
-        assert segment_moved[0].path == "hello0.txt"
-        assert segment_moved[1].path == "hello1.txt"
-        assert segment_moved[0].open().read() == "CONTENT_0"
-        assert segment_moved[1].open().read() == "CONTENT_1"
+    #     segment_moved = Segment("Segment1", client=dataset_client)
+    #     assert segment_moved[0].path == "hello0.txt"
+    #     assert segment_moved[1].path == "hello1.txt"
+    #     assert segment_moved[0].open().read() == "CONTENT_0"
+    #     assert segment_moved[1].open().read() == "CONTENT_1"
 
-        gas_client.delete_dataset(dataset_name)
+    #     gas_client.delete_dataset(dataset_name)
 
 
 class TestCopy:


### PR DESCRIPTION
TensorBay backend v2.7 does not support "override" and "skip" strategy
in move data feature.