### PR TITLE
feat(cli): support displaying error message for "gas auth"

### DIFF
--- a/docs/source/tensorbay_cli/cli_commands.rst
+++ b/docs/source/tensorbay_cli/cli_commands.rst
@@ -231,7 +231,7 @@ Create a draft with a title.
 
 .. code:: html
 
-   $ gas draft tb:<dataset_name> [-m <message>]
+   $ gas draft tb:<dataset_name> [-m <title>]
 
 List the drafts of a dataset.
 
@@ -243,7 +243,7 @@ Edit the draft of a dataset.
 
 .. code:: html
 
-   $ gas draft -e tb:<dataset_name>#<draft_number> [-m <message>]
+   $ gas draft -e tb:<dataset_name>#<draft_number> [-m <title>]
 
 Close the draft of a dataset.
 
@@ -258,11 +258,11 @@ Close the draft of a dataset.
 
 Work with commit operations.
 
-Commit a :ref:`reference/glossary:draft` with a message.
+Commit a :ref:`reference/glossary:draft` with a title.
 
 .. code:: html
 
-   $ gas commit tb:<dataset_name>#<draft_number> [-m <message>]
+   $ gas commit tb:<dataset_name>#<draft_number> [-m <title>]
 
 
 ***********

--- a/docs/source/tensorbay_cli/getting_started_with_cli.rst
+++ b/docs/source/tensorbay_cli/getting_started_with_cli.rst
@@ -80,7 +80,7 @@ CLI: Create a Draft
 
 .. code:: html
 
-   $ gas draft tb:<dataset_name> [-m <message>]
+   $ gas draft tb:<dataset_name> [-m <title>]
 
 
 CLI: List Drafts
@@ -104,7 +104,7 @@ CLI: Commit the Draft
 
 .. code:: html
 
-   $ gas commit tb:<dataset_name>#<draft_number> [-m <message>]
+   $ gas commit tb:<dataset_name>#<draft_number> [-m <title>]
 
 *********
  Profile

--- a/tensorbay/cli/cli.py
+++ b/tensorbay/cli/cli.py
@@ -163,7 +163,7 @@ def dataset(obj: Dict[str, str], tbrn: str, is_delete: bool, yes: bool) -> None:
     cls=DeprecatedOptionsCommand,
     synopsis=(
         "$ gas draft -l tb:<dataset_name>                                # List drafts.",
-        "$ gas draft tb:<dataset_name>[@<branch_name>] [-m <message>]    # Create a draft.",
+        "$ gas draft tb:<dataset_name>[@<branch_name>] [-m <title>]      # Create a draft.",
     ),
 )
 @click.argument("tbrn", type=str)
@@ -178,7 +178,7 @@ def dataset(obj: Dict[str, str], tbrn: str, is_delete: bool, yes: bool) -> None:
     type=str,
     multiple=True,
     default=(),
-    help="The message of the draft.",
+    help="The title of the draft.",
     deprecated=("-t", "--title"),
     preferred="-m",
     since="v1.8.0",
@@ -211,13 +211,11 @@ def draft(  # pylint: disable=too-many-arguments
 
 
 @command(
-    synopsis=(
-        "$ gas commit tb:<dataset_name>#<draft_number> [-m <message>]      # Commit a draft.",
-    )
+    synopsis=("$ gas commit tb:<dataset_name>#<draft_number> [-m <title>]      # Commit a draft.",)
 )
 @click.argument("tbrn", type=str)
 @click.option(
-    "-m", "--message", type=str, multiple=True, default=(), help="The message of the commit."
+    "-m", "--message", type=str, multiple=True, default=(), help="The title of the commit."
 )
 @click.pass_obj
 def commit(obj: Dict[str, str], tbrn: str, message: Tuple[str, ...]) -> None:


### PR DESCRIPTION
display error messages when the "profile" entered by user or
 the "profiles" section of config file doesn't exist