### PR TITLE
style: fix the errors, warnings and hints reported by "pyright" 1.1.159

### DIFF
--- a/tensorbay/client/lazy.py
+++ b/tensorbay/client/lazy.py
@@ -139,7 +139,7 @@ class LazyPage(Generic[_T]):  # pylint: disable=too-few-public-methods
 
     """
 
-    __slots__ = ("_offset", "_limit", "_func", "items")
+    __slots__: Tuple[str, ...] = ("_offset", "_limit", "_func", "items")
 
     def __init__(self, offset: int, limit: int, func: PagingGenerator[_T]) -> None:
         self.items: Tuple[LazyItem[_T], ...] = tuple(LazyItem.from_page(self) for _ in range(limit))
@@ -326,7 +326,7 @@ class PagingList(MutableSequence[_T], ReprMixin):  # pylint: disable=too-many-an
         if hasattr(self, "_items"):
             paging_list._items = self._items[slicing]
         else:
-            paging_list._init_items = lambda index: paging_list._init_sliced_items(self, slicing)
+            paging_list._init_items = lambda _: paging_list._init_sliced_items(self, slicing)
 
         return paging_list
 

--- a/tensorbay/geometry/point_list.py
+++ b/tensorbay/geometry/point_list.py
@@ -40,7 +40,7 @@ class PointList2D(UserMutableSequence[_T]):  # pylint: disable=too-many-ancestor
     ) -> None:
         self._data = [self._ElementType(*point) for point in points] if points else []
 
-    def _loads(self: _P, contents: List[Dict[str, float]]) -> None:
+    def _loads(self, contents: List[Dict[str, float]]) -> None:
         self._data = []
         for point in contents:
             self._data.append(self._ElementType.loads(point))
@@ -123,7 +123,7 @@ class MultiPointList2D(UserMutableSequence[_L]):  # pylint: disable=too-many-anc
             [self._ElementType(point_list) for point_list in point_lists] if point_lists else []
         )
 
-    def _loads(self: _P, contents: List[List[Dict[str, float]]]) -> None:
+    def _loads(self, contents: List[List[Dict[str, float]]]) -> None:
         self._data = [self._ElementType.loads(point_list) for point_list in contents]
 
     def _dumps(self) -> List[List[Dict[str, float]]]:

--- a/tensorbay/sensor/intrinsics.py
+++ b/tensorbay/sensor/intrinsics.py
@@ -320,8 +320,8 @@ class DistortionCoefficients(ReprMixin, AttrsMixin):
         if is_fisheye:
             return (0, 0)
 
-        p1 = self.p1  # type: ignore[attr-defined]  # pylint: disable=no-member
-        p2 = self.p2  # type: ignore[attr-defined]  # pylint: disable=no-member
+        p1: float = self.p1  # type: ignore[attr-defined]  # pylint: disable=no-member
+        p2: float = self.p2  # type: ignore[attr-defined]  # pylint: disable=no-member
         return (p1 * xy2 + p2 * (r2 + 2 * x2), p1 * (r2 + 2 * y2) + p2 * xy2)
 
     def _loads(self, contents: Dict[str, float]) -> None:

--- a/tensorbay/utility/attr.py
+++ b/tensorbay/utility/attr.py
@@ -307,7 +307,7 @@ def _get_operators(annotation: Any) -> Tuple[_Callable, _Callable]:
         Operating methods of the annotation.
 
     """
-    origin = _get_origin(annotation)
+    origin: Any = _get_origin(annotation)
     annotation_args = getattr(annotation, "__args__", ())
     if isinstance(origin, type) and issubclass(origin, Sequence):
         type_ = annotation_args[0]

--- a/tensorbay/utility/common.py
+++ b/tensorbay/utility/common.py
@@ -20,7 +20,6 @@ from typing import Any, Callable, DefaultDict, Sequence, Type, TypeVar, Union
 import numpy as np
 
 _T = TypeVar("_T")
-_Callable = TypeVar("_Callable", bound=Callable[..., Any])
 _CallableWithoutReturnValue = TypeVar("_CallableWithoutReturnValue", bound=Callable[..., None])
 
 


### PR DESCRIPTION
-   tensorbay/client/lazy.py:
```python
181: [Pyright reportGeneralTypeIssues] [E] Operator "+" not supported for types
"str | Iterable[str]" and "tuple[Literal['total_count']]"
```
```python
329: [Pyright] [H] "index" is not accessed
```

-   tensorbay/geometry/point_list.py:
```python
43: [Pyright reportInvalidTypeVarUse] [W] TypeVar "\_P" appears only once in
generic function signature
```
```python
126: [Pyright reportInvalidTypeVarUse] [W] TypeVar "\_P" appears only once in
generic function signature
```

-   tensorbay/sensor/intrinsics.py:
```python
325: [Pyright reportGeneralTypeIssues] [E] Operator "\*" not supported for
types "NoReturn" and "float"
```

-   tensorbay/utility/attr.py:
```python
333: [Pyright reportOptionalCall] [E] Object of type "None" cannot be called
```

-   tensorbay/utility/common.py
```python
23: [Pyright] [H] "\_Callable" is not accessed
```