### PR TITLE
refactor!: add "get_callback_body" to replace "dumps" in "Data"

### DIFF
--- a/tensorbay/dataset/data.py
+++ b/tensorbay/dataset/data.py
@@ -102,15 +102,17 @@ class Data(DataBase, FileMixin):
     def target_remote_path(self, target_remote_path: str) -> None:
         self._target_remote_path = target_remote_path
 
-    def dumps(self) -> Dict[str, Any]:
-        """Dumps the local data into a dict.
+    def get_callback_body(self) -> Dict[str, Any]:
+        """Get the callback request body for uploading.
 
         Returns:
-            Dumped data dict, which looks like::
+            The callback request body, which look like::
 
                     {
-                        "localPath": <str>,
+                        "remotePath": <str>,
                         "timestamp": <float>,
+                        "checksum": <str>,
+                        "fileSize": <int>,
                         "label": {
                             "CLASSIFICATION": {...},
                             "BOX2D": {...},
@@ -123,7 +125,14 @@ class Data(DataBase, FileMixin):
                     }
 
         """
-        return super()._dumps()
+        body = super()._get_callback_body()
+        body["remotePath"] = self.target_remote_path
+        if hasattr(self, "timestamp"):
+            body["timestamp"] = self.timestamp
+        if self.label:
+            body["label"] = self.label.dumps()
+
+        return body
 
 
 class RemoteData(DataBase, RemoteFileMixin):
@@ -249,29 +258,6 @@ class AuthData(DataBase, RemoteFileMixin):
         DataBase.__init__(self, timestamp)
         RemoteFileMixin.__init__(self, cloud_path, _url_getter=_url_getter)
         self._target_remote_path = target_remote_path
-
-    def dumps(self) -> Dict[str, Any]:
-        """Dumps the auth data into a dict.
-
-        Returns:
-            Dumped data dict, which looks like::
-
-                    {
-                        "cloudPath": <str>,
-                        "timestamp": <float>,
-                        "label": {
-                            "CLASSIFICATION": {...},
-                            "BOX2D": {...},
-                            "BOX3D": {...},
-                            "POLYGON": {...},
-                            "POLYLINE2D": {...},
-                            "KEYPOINTS2D": {...},
-                            "SENTENCE": {...}
-                        }
-                    }
-
-        """
-        return super()._dumps()
 
     @property
     def target_remote_path(self) -> str:

--- a/tensorbay/dataset/frame.py
+++ b/tensorbay/dataset/frame.py
@@ -121,29 +121,6 @@ class Frame(UserMutableMapping[str, "DataBase._Type"]):
     #     """
     #     return self._pose
 
-    def dumps(self) -> Dict[str, Any]:
-        """Dumps the current frame into a dict.
-
-        Returns:
-            A dict containing all the information of the frame.
-
-        """
-        contents: Dict[str, Any] = {}
-        # if self._pose:
-        #     contents["pose"] = self._pose.dumps()
-        if hasattr(self, "frame_id"):
-            contents["frameId"] = str(self.frame_id)
-
-        frame = []
-        for sensor_name, data in self._data.items():
-            data_contents = {"sensorName": sensor_name}
-            data_contents.update(data.dumps())
-            frame.append(data_contents)
-
-        contents["frame"] = frame
-
-        return contents
-
     # def set_pose(
     #     self,
     #     translation: Optional[Iterable[float]] = (0, 0, 0),

--- a/tensorbay/dataset/tests/test_data.py
+++ b/tensorbay/dataset/tests/test_data.py
@@ -24,9 +24,20 @@ class TestData:
         assert data.target_remote_path == target_remote_path
         assert data.timestamp == timestamp
 
-    def test_dumps(self):
-        data = Data("test.json", timestamp=_DATA["timestamp"])
-        assert data.dumps() == _DATA
+    def test_get_callback_body(self, tmp_path):
+        local_path = tmp_path / "file"
+        local_path.write_text("CONTENT")
+
+        timestamp = 1234
+
+        data = Data(str(local_path), timestamp=timestamp)
+
+        assert data.get_callback_body() == {
+            "checksum": "238a131a3e8eb98d1fc5b27d882ca40b7618fd2a",
+            "fileSize": 7,
+            "remotePath": local_path.name,
+            "timestamp": timestamp,
+        }
 
     def test_target_remote_path(self):
         target_remote_path = "test2.json"
@@ -62,5 +73,5 @@ class TestRemoteData:
         assert data.timestamp == _REMOTE_DATA["timestamp"]
 
     def test_dumps(self):
-        data = RemoteData("test.json", timestamp=_DATA["timestamp"])
+        data = RemoteData("test.json", timestamp=_REMOTE_DATA["timestamp"])
         assert data.dumps() == _REMOTE_DATA

--- a/tensorbay/dataset/tests/test_frame.py
+++ b/tensorbay/dataset/tests/test_frame.py
@@ -45,9 +45,3 @@ class TestFrame:
         assert frame["sensor1"].timestamp == 1614945883
         assert frame["sensor2"].path == "test2.png"
         assert frame["sensor2"].timestamp == 1614945884
-
-    def test_dumps(self):
-        frame = Frame(_FRAME_ID)
-        frame["sensor1"] = RemoteData("test1.png", timestamp=1614945883)
-        frame["sensor2"] = RemoteData("test2.png", timestamp=1614945884)
-        assert frame.dumps() == _FRAME_DATA


### PR DESCRIPTION
BREAKING CHANGE: The following methods are removed:
- `Data.dumps`
- `RemoteData.dumps`
- `AuthData.dumps`
- `Frame.dumps`