### PR TITLE
refactor!: add from_response_body to replace loads in RemoteData & Frame

### DIFF
--- a/tensorbay/client/segment.py
+++ b/tensorbay/client/segment.py
@@ -318,10 +318,10 @@ class SegmentClient(SegmentClientBase):
         response = self._list_labels(offset, limit)
 
         for i, item in enumerate(response["labels"], offset):
-            data = RemoteData.loads(item)
-            # pylint: disable=protected-access
-            data._url_getter = lambda _, i=i: urls[i]  # type: ignore[misc]
-            yield data
+            yield RemoteData.from_response_body(
+                item,
+                _url_getter=lambda _, i=i: urls[i],  # type: ignore[misc]
+            )
 
         return response["totalCount"]  # type: ignore[no-any-return]
 
@@ -626,14 +626,8 @@ class FusionSegmentClient(SegmentClientBase):
     ) -> Generator[Frame, None, int]:
         response = self._list_labels(offset, limit)
 
-        data: RemoteData
-        for i, item in enumerate(response["labels"], offset):
-            frame = Frame.loads(item)
-            # pylint: disable=no-member # pylint issue: #3131
-            for sensor_name, data in frame.items():  # type: ignore[assignment]
-                # pylint: disable=protected-access
-                data._url_getter = lambda _, i=i, s=sensor_name: urls[i][s]  # type: ignore[misc]
-            yield frame
+        for index, item in enumerate(response["labels"], offset):
+            yield Frame.from_response_body(item, index, urls)
 
         return response["totalCount"]  # type: ignore[no-any-return]
 

--- a/tensorbay/dataset/tests/test_data.py
+++ b/tensorbay/dataset/tests/test_data.py
@@ -67,11 +67,8 @@ class TestRemoteData:
         with pytest.raises(ValueError):
             remote_data.get_url()
 
-    def test_loads(self):
-        data = RemoteData.loads(_REMOTE_DATA)
+    def test_from_response_body(self):
+        data = RemoteData.from_response_body(_REMOTE_DATA, _url_getter=lambda _: "url")
         assert data.path == _REMOTE_DATA["remotePath"]
         assert data.timestamp == _REMOTE_DATA["timestamp"]
-
-    def test_dumps(self):
-        data = RemoteData("test.json", timestamp=_REMOTE_DATA["timestamp"])
-        assert data.dumps() == _REMOTE_DATA
+        assert data.get_url() == "url"

--- a/tensorbay/dataset/tests/test_frame.py
+++ b/tensorbay/dataset/tests/test_frame.py
@@ -38,10 +38,12 @@ class TestFrame:
         assert frame.frame_id == _FRAME_ID
         assert frame._data == {}
 
-    def test_loads(self):
-        frame = Frame.loads(_FRAME_DATA)
+    def test_from_response_body(self):
+        frame = Frame.from_response_body(_FRAME_DATA, 0, [{"sensor1": "url1", "sensor2": "url2"}])
         assert frame.frame_id == _FRAME_ID
         assert frame["sensor1"].path == "test1.png"
         assert frame["sensor1"].timestamp == 1614945883
+        assert frame["sensor1"].get_url() == "url1"
         assert frame["sensor2"].path == "test2.png"
         assert frame["sensor2"].timestamp == 1614945884
+        assert frame["sensor2"].get_url() == "url2"


### PR DESCRIPTION
BREAKING CHANGE: The following methods are removed:
- `RemoteData.loads`
- `RemoteData.dumps`
- `Frame.loads`