### PR TITLE
fix(exception): fix AttributeError when calling "ResponseError.response"

### DIFF
--- a/tensorbay/exception.py
+++ b/tensorbay/exception.py
@@ -131,7 +131,7 @@ class ResponseError(ClientError):
         self, message: Optional[str] = None, *, response: Optional[Response] = None
     ) -> None:
         super().__init__(message)
-        if response:
+        if response is not None:
             self.response = response
 
     def __init_subclass__(cls) -> None:


### PR DESCRIPTION
Root Cause:
The `__bool__()` of `request.models.Response` returns `self.ok`,
it is `False` when the status code not less than 400. Thus the `response`
attribute of `ResponseError` will never be set.

Solution:
Check whether the `response` argument is `None` or not instead of using
its bool value.