### PR TITLE
fix(label): add a workaround for IndexError when load panoptic mask

### DIFF
--- a/tensorbay/label/label_mask.py
+++ b/tensorbay/label/label_mask.py
@@ -502,8 +502,11 @@ class RemotePanopticMask(PanopticMaskBase, RemoteFileMixin):
         """
         mask = cls(body["remotePath"])
         info = body["info"]
-        mask.all_category_ids = {item["instanceId"]: item["categoryId"] for item in info}
-        if "attributes" in info[0]:
-            mask.all_attributes = {item["instanceId"]: item["attributes"] for item in body["info"]}
+        # Workaround for panoptic masks with empty info.
+        # TODO: Remove this check after reuploading COCO mask labels or changing standards.
+        if info:
+            mask.all_category_ids = {item["instanceId"]: item["categoryId"] for item in info}
+            if "attributes" in info[0]:
+                mask.all_attributes = {item["instanceId"]: item["attributes"] for item in info}
 
         return mask


### PR DESCRIPTION
COCO dataset has panoptic masks with empty info, whose pixel values are
all zeros. When calling `RemotePanopticMask.from_response_body()`,
IndexError may occur.