### PR TITLE
ci: upgrade prettier, yamllint, markdownlint-cli in pre-commit check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,7 +68,7 @@ repos:
           ]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v2.2.1
+    rev: v2.4.1
     hooks:
       - id: prettier
         types_or: [markdown, json]
@@ -79,7 +79,7 @@ repos:
         args: ["--print-width=100", "--tab-width=2"]
 
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.26.0
+    rev: v1.26.3
     hooks:
       - id: yamllint
         types: [yaml]
@@ -104,7 +104,7 @@ repos:
           ]
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.27.1
+    rev: v0.28.1
     hooks:
       - id: markdownlint
         types: [markdown]


### PR DESCRIPTION
- `prettier`: 2.2.1 -> 2.4.1
- `yamllint`: 1.26.0 -> 1.26.3
- `markdownlint-cli`: 0.27.1 -> 0.28.1