### PR TITLE
refactor: add argument "encoding='utf-8'" to open()

### DIFF
--- a/tensorbay/cli/utility.py
+++ b/tensorbay/cli/utility.py
@@ -195,7 +195,7 @@ class ContextInfo:
             )
 
         config_file = self._get_config_filepath()
-        with open(config_file, "w") as fp:
+        with open(config_file, "w", encoding="utf-8") as fp:
             config_parser.write(fp)
         if show_message:
             click.echo(f'Success!\nConfiguration has been written into: "{config_file}"')

--- a/tensorbay/client/profile.py
+++ b/tensorbay/client/profile.py
@@ -79,13 +79,13 @@ class Profile:
         return 0
 
     def _save_to_txt(self, path: str) -> None:
-        with open(path, "w") as fp:
+        with open(path, "w", encoding="utf-8") as fp:
             fp.write(self._format_string())
             for url, item in self._summary.items():
                 fp.write(self._format_string(url, item))
 
     def _save_to_csv(self, path: str) -> None:
-        with open(path, "w") as fp:
+        with open(path, "w", encoding="utf-8") as fp:
             writer = csv.writer(fp)
             writer.writerow(chain(["Path"], _COLUMNS.keys()))
             for post, item in self._summary.items():
@@ -93,7 +93,7 @@ class Profile:
 
     def _save_to_json(self, path: str) -> None:
         summary = self._summary if isinstance(self._summary, dict) else self._summary.copy()
-        with open(path, "w") as fp:
+        with open(path, "w", encoding="utf-8") as fp:
             json.dump(summary, fp, indent=4)
 
     def _statistical(self, func: _Callable) -> _Callable:

--- a/tensorbay/dataset/dataset.py
+++ b/tensorbay/dataset/dataset.py
@@ -280,7 +280,7 @@ class DatasetBase(Sequence[_T], NameMixin):  # pylint: disable=too-many-ancestor
             filepath: The path of the json file which contains the catalog information.
 
         """
-        with open(filepath, "r") as fp:
+        with open(filepath, "r", encoding="utf-8") as fp:
             contents = json.load(fp)
         self._catalog = Catalog.loads(contents)
 

--- a/tensorbay/dataset/tests/test_dataset.py
+++ b/tensorbay/dataset/tests/test_dataset.py
@@ -70,7 +70,7 @@ class TestDatasetBase:
         )
         dataset = DatasetBase("test_name")
         dataset.load_catalog(catalog_path)
-        with open(catalog_path) as fp:
+        with open(catalog_path, encoding="utf-8") as fp:
             catalog = json.load(fp)
         assert dataset.catalog.dumps() == catalog
 

--- a/tensorbay/opendataset/AADB/loader.py
+++ b/tensorbay/opendataset/AADB/loader.py
@@ -76,7 +76,7 @@ def _extract_attributes_map(
     for attribute_name in attribute_names:
         label_file_name = f"{label_file_prefix}_{attribute_name}.txt"
         label_file_path = os.path.join(label_dir, label_file_name)
-        with open(label_file_path) as fp:
+        with open(label_file_path, encoding="utf-8") as fp:
             # one line of file looks like:
             # "<image_name> value"
             for line in fp:

--- a/tensorbay/opendataset/BDD100K/loader.py
+++ b/tensorbay/opendataset/BDD100K/loader.py
@@ -309,7 +309,7 @@ def _read_label_file_100k(label_dir: str, segment_name: str) -> Dict[str, Any]:
 
         label_description = _LABEL_TYPE_INFO_100K[label_prefix][0]
         print(f"Reading '{label_description}' labels to segment '{segment_name}'...")
-        with open(label_filename, "r") as fp:
+        with open(label_filename, "r", encoding="utf-8") as fp:
             source_label_contents.append(json.load(fp))
         print(f"Finished reading '{label_description}' labels to segment '{segment_name}'...")
 
@@ -330,7 +330,7 @@ def _read_label_file_100k(label_dir: str, segment_name: str) -> Dict[str, Any]:
 def _read_label_file_10k(label_dir: str, segment_name: str) -> Dict[str, Any]:
     source_label_contents = []
     label_filename = os.path.join(label_dir, "pan_seg", "polygons", f"pan_seg_{segment_name}.json")
-    with open(label_filename, "r") as fp:
+    with open(label_filename, "r", encoding="utf-8") as fp:
         source_label_contents.append(json.load(fp))
 
     print(f"Merging '{segment_name}' labels...")
@@ -403,11 +403,11 @@ def _save_and_get_mask_info(
             if seg_type == "pan"
             else {"all_attributes": all_attributes}
         )
-        with open(mask_info_path, "w") as fp:
+        with open(mask_info_path, "w", encoding="utf-8") as fp:
             json.dump(mask_info, fp)
         Image.fromarray(mask[:, :, -1]).save(mask_path)
     else:
-        with open(mask_info_path, "r") as fp:
+        with open(mask_info_path, "r", encoding="utf-8") as fp:
             mask_info = json.load(
                 fp,
                 object_hook=lambda info: {

--- a/tensorbay/opendataset/BDD100K_MOT2020/loader.py
+++ b/tensorbay/opendataset/BDD100K_MOT2020/loader.py
@@ -192,7 +192,7 @@ def _generate_data(
         original_mask_subdir = os.path.join(original_mask_dir, subdir_name)
         mask_subdir = os.path.join(mask_dir, subdir_name)
         os.makedirs(mask_subdir, exist_ok=True)
-    with open(os.path.join(segment_labels_dir, f"{subdir_name}.json"), "r") as fp:
+    with open(os.path.join(segment_labels_dir, f"{subdir_name}.json"), "r", encoding="utf-8") as fp:
         label_contents = json.load(fp)
     for label_content in label_contents:
         label_content_name = label_content["name"]
@@ -285,11 +285,11 @@ def _save_and_get_mask_info(
                 "ignore": bool(attributes & 1),
             }
         mask_info = {"all_attributes": all_attributes}
-        with open(mask_info_path, "w") as fp:
+        with open(mask_info_path, "w", encoding="utf-8") as fp:
             json.dump(mask_info, fp)
         Image.fromarray(mask[:, :, -1] + (mask[:, :, -2] << 8)).save(mask_path)
     else:
-        with open(mask_info_path, "r") as fp:
+        with open(mask_info_path, "r", encoding="utf-8") as fp:
             mask_info = json.load(
                 fp,
                 object_hook=lambda info: {

--- a/tensorbay/opendataset/CADC/loader.py
+++ b/tensorbay/opendataset/CADC/loader.py
@@ -91,7 +91,7 @@ def CADC(path: str) -> FusionDataset:
             segment_path = os.path.join(root_path, date, index)
             data_path = os.path.join(segment_path, "labeled")
 
-            with open(os.path.join(segment_path, "3d_ann.json"), "r") as fp:
+            with open(os.path.join(segment_path, "3d_ann.json"), "r", encoding="utf-8") as fp:
                 # The first line of the json file is the json body.
                 annotations = json.loads(fp.readline())
             timestamps = _load_timestamps(sensors, data_path)
@@ -106,7 +106,7 @@ def _load_timestamps(sensors: Sensors, data_path: str) -> Dict[str, List[str]]:
     for sensor_name in sensors.keys():
         data_folder = f"image_{sensor_name[-2:]}" if sensor_name != "LIDAR" else "lidar_points"
         timestamp_file = os.path.join(data_path, data_folder, "timestamps.txt")
-        with open(timestamp_file, "r") as fp:
+        with open(timestamp_file, "r", encoding="utf-8") as fp:
             timestamps[sensor_name] = fp.readlines()
 
     return timestamps
@@ -197,11 +197,11 @@ def _load_sensors(calib_path: str) -> Sensors:
     lidar.set_extrinsics()
     sensors.add(lidar)
 
-    with open(os.path.join(calib_path, "extrinsics.yaml"), "r") as fp:
+    with open(os.path.join(calib_path, "extrinsics.yaml"), "r", encoding="utf-8") as fp:
         extrinsics = yaml.load(fp, Loader=yaml.FullLoader)
 
     for camera_calibration_file in glob(os.path.join(calib_path, "[0-9]*.yaml")):
-        with open(camera_calibration_file, "r") as fp:
+        with open(camera_calibration_file, "r", encoding="utf-8") as fp:
             camera_calibration = yaml.load(fp, Loader=yaml.FullLoader)
 
         # camera_calibration_file looks like:

--- a/tensorbay/opendataset/CCPD/loader.py
+++ b/tensorbay/opendataset/CCPD/loader.py
@@ -244,7 +244,7 @@ def _get_polygons(image_path: str) -> List[LabeledPolygon]:
 def _get_ccpd_image_path(root_path: str, segment_head: str, segment_tail: str) -> Iterator[str]:
     if segment_tail == "base":
         file_path = os.path.join(root_path, "splits", f"{segment_head}.txt")
-        with open(file_path, "r") as fp:
+        with open(file_path, "r", encoding="utf-8") as fp:
             for image_path in fp:
                 yield os.path.join(root_path, image_path.strip())
     else:

--- a/tensorbay/opendataset/CIHP/loader.py
+++ b/tensorbay/opendataset/CIHP/loader.py
@@ -67,7 +67,9 @@ def CIHP(path: str) -> Dataset:
         segment = dataset.create_segment(segment_name)
         segment_abspath = os.path.join(root_path, segment_path)
         image_path = os.path.join(segment_abspath, "Images")
-        with open(os.path.join(segment_abspath, f"{segment_name}_id.txt"), "r") as fp:
+        with open(
+            os.path.join(segment_abspath, f"{segment_name}_id.txt"), "r", encoding="utf-8"
+        ) as fp:
             if segment_name == "test":
                 for filename in fp:
                     segment.append(Data(os.path.join(image_path, f"{filename.rstrip()}.jpg")))

--- a/tensorbay/opendataset/COCO2017/loader.py
+++ b/tensorbay/opendataset/COCO2017/loader.py
@@ -115,7 +115,9 @@ def COCO2017(path: str) -> Dataset:
 def _get_information(annotation_path: str, segment_name: str) -> Dict[str, Any]:
     task_information: Dict[str, Any] = {}
     for task in ("instances", "person_keypoints", "panoptic"):
-        with open(os.path.join(annotation_path, f"{task}_{segment_name}2017.json"), "r") as fp:
+        with open(
+            os.path.join(annotation_path, f"{task}_{segment_name}2017.json"), "r", encoding="utf-8"
+        ) as fp:
             file_json = json.load(fp)
 
         task_annotation: DefaultDict[int, Any] = defaultdict(list)

--- a/tensorbay/opendataset/COVIDChestXRay/loader.py
+++ b/tensorbay/opendataset/COVIDChestXRay/loader.py
@@ -60,7 +60,7 @@ def COVIDChestXRay(path: str) -> Dataset:
 
     csv_path = os.path.join(root_path, "metadata.csv")
 
-    with open(csv_path) as fp:
+    with open(csv_path, encoding="utf-8") as fp:
         csv_reader = csv.DictReader(fp)
         for attributes in csv_reader:
             folder = attributes.pop("folder")

--- a/tensorbay/opendataset/COVID_CT/loader.py
+++ b/tensorbay/opendataset/COVID_CT/loader.py
@@ -70,7 +70,9 @@ def COVID_CT(path: str) -> Dataset:
     for segment_name, (split_filename, image_dir, category) in _SEGMENT_TO_PATH.items():
         segment = dataset.create_segment(segment_name)
         image_dir = os.path.join(images_processed_path, image_dir)
-        with open(os.path.join(data_split_path, category, split_filename), "r") as fp:
+        with open(
+            os.path.join(data_split_path, category, split_filename), "r", encoding="utf-8"
+        ) as fp:
             for line in fp:
                 image_path = os.path.join(image_dir, line.strip("\n"))
                 data = Data(image_path)

--- a/tensorbay/opendataset/LIP/loader.py
+++ b/tensorbay/opendataset/LIP/loader.py
@@ -76,13 +76,15 @@ def LIP(path: str) -> Dataset:
         segment = dataset.create_segment(segment_name)
         if segment_name == "test":
             image_path = os.path.join(test_path, "testing_images")
-            with open(os.path.join(test_path, "test_id.txt"), "r") as fp:
+            with open(os.path.join(test_path, "test_id.txt"), "r", encoding="utf-8") as fp:
                 for filename in fp:
                     segment.append(Data(os.path.join(image_path, f"{filename.rstrip()}.jpg")))
         else:
             image_path = os.path.join(trainval_image_path, f"{segment_name}_images")
             parsing_path = os.path.join(trainval_parsing_path, f"{segment_name}_segmentations")
-            with open(os.path.join(pose_path, f"lip_{segment_name}_set.csv"), "r") as csvfile:
+            with open(
+                os.path.join(pose_path, f"lip_{segment_name}_set.csv"), "r", encoding="utf-8"
+            ) as csvfile:
                 for keypoints_info in csv.reader(csvfile):
                     segment.append(_get_data(keypoints_info, image_path, parsing_path))
     return dataset

--- a/tensorbay/opendataset/LISATrafficSign/loader.py
+++ b/tensorbay/opendataset/LISATrafficSign/loader.py
@@ -110,7 +110,7 @@ def _load_positive_segment(segment_name: str, segment_path: str) -> Segment:
     )[0]
     image_folder = os.path.dirname(annotation_file)
     pre_filename = ""
-    with open(annotation_file, "r") as fp:
+    with open(annotation_file, "r", encoding="utf-8") as fp:
         for annotation in csv.DictReader(fp, delimiter=";"):
             filename = annotation["Filename"]
 

--- a/tensorbay/opendataset/UAVDT/loader.py
+++ b/tensorbay/opendataset/UAVDT/loader.py
@@ -105,7 +105,7 @@ def UAVDT(path: str) -> Dataset:
 def _extract_classification(
     path: str, classification_catalog: ClassificationSubcatalog
 ) -> Classification:
-    with open(path) as fp:
+    with open(path, encoding="utf-8") as fp:
         attribute_names = classification_catalog.attributes.keys()
         csv_reader = csv.reader(fp)
         elements = next(csv_reader)
@@ -128,7 +128,7 @@ def _extract_box2d(
 
     ground_truth_path = os.path.join(path, "UAV-benchmark-MOTD_v1.0", "GT")
     frame_id_ground_truth_map = defaultdict(list)
-    with open(os.path.join(ground_truth_path, f"{sequence}_gt_whole.txt")) as fp:
+    with open(os.path.join(ground_truth_path, f"{sequence}_gt_whole.txt"), encoding="utf-8") as fp:
         for elements in csv.DictReader(fp, fieldnames=_FIELDNAMES):
             box2d = LabeledBox2D.from_xywh(
                 *(int(elements[key]) for key in _XYWH_KEYS),

--- a/tensorbay/opendataset/VOC2012ActionClassification/loader.py
+++ b/tensorbay/opendataset/VOC2012ActionClassification/loader.py
@@ -53,7 +53,7 @@ def VOC2012ActionClassification(path: str) -> Dataset:
 
     for segment_name in _SEGMENT_NAMES:
         segment = dataset.create_segment(segment_name)
-        with open(os.path.join(action_path, f"{segment_name}.txt")) as fp:
+        with open(os.path.join(action_path, f"{segment_name}.txt"), encoding="utf-8") as fp:
             for filename in fp:
                 filename = filename.strip()
                 segment.append(_get_data(filename, image_path, annotation_path))
@@ -68,7 +68,7 @@ def _get_data(filename: str, image_path: str, annotation_path: str) -> Data:
 
     data = Data(os.path.join(image_path, f"{filename}.jpg"))
     box2d = []
-    with open(os.path.join(annotation_path, f"{filename}.xml"), "r") as fp:
+    with open(os.path.join(annotation_path, f"{filename}.xml"), "r", encoding="utf-8") as fp:
         objects = xmltodict.parse(fp.read())["annotation"]["object"]
     if not isinstance(objects, list):
         objects = [objects]

--- a/tensorbay/opendataset/VOC2012Detection/loader.py
+++ b/tensorbay/opendataset/VOC2012Detection/loader.py
@@ -54,7 +54,7 @@ def VOC2012Detection(path: str) -> Dataset:
 
     for segment_name in _SEGMENT_NAMES:
         segment = dataset.create_segment(segment_name)
-        with open(os.path.join(main_path, f"{segment_name}.txt")) as fp:
+        with open(os.path.join(main_path, f"{segment_name}.txt"), encoding="utf-8") as fp:
             for filename in fp:
                 filename = filename.strip()
                 segment.append(_get_data(filename, image_path, annotation_path))

--- a/tensorbay/opendataset/VOC2012Segmentation/loader.py
+++ b/tensorbay/opendataset/VOC2012Segmentation/loader.py
@@ -57,7 +57,7 @@ def VOC2012Segmentation(path: str) -> Dataset:
 
     for segment_name in _SEGMENT_NAMES:
         segment = dataset.create_segment(segment_name)
-        with open(os.path.join(image_set_path, f"{segment_name}.txt")) as fp:
+        with open(os.path.join(image_set_path, f"{segment_name}.txt"), encoding="utf-8") as fp:
             for stem in fp:
                 stem = stem.strip()
                 data = Data(os.path.join(image_path, f"{stem}.jpg"))

--- a/tensorbay/opendataset/_utility/nuScenes.py
+++ b/tensorbay/opendataset/_utility/nuScenes.py
@@ -33,7 +33,7 @@ def get_info_with_token(info_path: str, annotation_part: str) -> Dict[str, Any]:
 
     """
     filepath = os.path.join(info_path, f"{annotation_part}.json")
-    with open(filepath, "r") as fp:
+    with open(filepath, "r", encoding="utf-8") as fp:
         info = json.load(fp)
     return {item.pop("token"): item for item in info}
 
@@ -57,7 +57,7 @@ def get_info_with_determined_token(
 
     """
     filepath = os.path.join(info_path, f"{annotation_part}.json")
-    with open(filepath, "r") as fp:
+    with open(filepath, "r", encoding="utf-8") as fp:
         info = json.load(fp)
     info_with_keys: Dict[str, List[Any]] = {}
     for item in info:

--- a/tensorbay/opendataset/nuScenes/loader.py
+++ b/tensorbay/opendataset/nuScenes/loader.py
@@ -141,7 +141,7 @@ def _get_annotation_info(info_path: str, is_test: bool = False) -> Dict[str, Any
         "ego_poses": get_info_with_token(info_path, "ego_pose"),
         "sensor": get_info_with_token(info_path, "sensor"),
     }
-    with open(os.path.join(info_path, "scene.json"), "r") as file:
+    with open(os.path.join(info_path, "scene.json"), "r", encoding="utf-8") as file:
         annotation_info["scenes"] = json.load(file)
     if not is_test:
         annotation_info["sample_annotations"] = get_info_with_determined_token(


### PR DESCRIPTION
reason: Unlike macOS and Linux, Windows's default encoding is not
always UTF-8. Therefore, adding the argument above could help maintain
consistency in all three systems.