### PR TITLE
build: add file "tensorbay/py.typed" to comply with PEP-561

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,9 @@ exclude =
     *.tests
 
 [options.package_data]
-tensorbay = opendataset/*/catalog*.json
+tensorbay =
+    opendataset/*/catalog*.json
+    py.typed
 
 [options.entry_points]
 console_scripts = gas = tensorbay.cli.cli:cli

--- a/tensorbay/py.typed
+++ b/tensorbay/py.typed
@@ -1,0 +1,3 @@
+#
+# Copyright 2021 Graviti. Licensed under MIT License.
+#


### PR DESCRIPTION
The file "py.typed" tells the type hint checkers like mypy this is a
package supporting typing.

Reference:
- https://www.python.org/dev/peps/pep-0561/
- https://mypy.readthedocs.io/en/stable/installed_packages.html