### PR TITLE
refactor(client): correct the wrong variable name in Draft

### DIFF
--- a/tensorbay/client/struct.py
+++ b/tensorbay/client/struct.py
@@ -445,7 +445,7 @@ class Draft(AttrsMixin, ReprMixin):  # pylint: disable=too-many-instance-attribu
         status: The status of the draft.
         parent_commit_id: The parent commit id.
         author: The author of the draft.
-        updated_at: The time of last update.
+        update_at: The time of last update.
         description: The draft description.
 
     """
@@ -460,7 +460,7 @@ class Draft(AttrsMixin, ReprMixin):  # pylint: disable=too-many-instance-attribu
     status: str = attr()
     parent_commit_id: str = attr(key=camel)
     author: User = attr()
-    updated_at: int = attr(key=camel)
+    update_at: int = attr(key=camel)
     description: str = attr(default="")
 
     def __init__(  # pylint: disable=too-many-arguments
@@ -471,7 +471,7 @@ class Draft(AttrsMixin, ReprMixin):  # pylint: disable=too-many-instance-attribu
         status: str,
         parent_commit_id: str,
         author: User,
-        updated_at: int,
+        update_at: int,
         description: str = "",
     ) -> None:
         self.number = number
@@ -480,7 +480,7 @@ class Draft(AttrsMixin, ReprMixin):  # pylint: disable=too-many-instance-attribu
         self.status = status
         self.parent_commit_id = parent_commit_id
         self.author = author
-        self.updated_at = updated_at
+        self.update_at = update_at
         self.description = description
 
     def _repr_head(self) -> str:
@@ -503,7 +503,7 @@ class Draft(AttrsMixin, ReprMixin):  # pylint: disable=too-many-instance-attribu
                             "name": <str>
                             "date": <int>
                         }
-                        "updatedAt": <int>
+                        "updateAt": <int>
                         "description": <str>
                     }
 
@@ -529,7 +529,7 @@ class Draft(AttrsMixin, ReprMixin):  # pylint: disable=too-many-instance-attribu
                         "name": <str>
                         "date": <int>
                     }
-                    "updatedAt": <int>
+                    "updateAt": <int>
                     "description": <str>
                 }
 

--- a/tensorbay/client/tests/test_struct.py
+++ b/tensorbay/client/tests/test_struct.py
@@ -42,7 +42,7 @@ _DRAFT_TITLE = "draft title"
 _DRAFT_BRANCH_NAME = "main"
 _DRAFT_STATUS = "OPEN"
 _DRAFT_PARENT_COMMIT_ID = "4c564ea07f4e47679ec8c63d238bb3a1"
-_DRAFT_UPDATED_AT = 1637223060
+_DRAFT_UPDATE_AT = 1637223060
 _DRAFT_AUTHOR = User("draft author", 1636967807)
 _DRAFT_DESCRIPTION = "description"
 _DRAFT_DATA = {
@@ -52,7 +52,7 @@ _DRAFT_DATA = {
     "status": _DRAFT_STATUS,
     "parentCommitId": _DRAFT_PARENT_COMMIT_ID,
     "author": {"name": "draft author", "date": 1636967807},
-    "updatedAt": _DRAFT_UPDATED_AT,
+    "updateAt": _DRAFT_UPDATE_AT,
 }
 
 
@@ -151,7 +151,7 @@ class TestDraft:
             _DRAFT_STATUS,
             _DRAFT_PARENT_COMMIT_ID,
             _DRAFT_AUTHOR,
-            _DRAFT_UPDATED_AT,
+            _DRAFT_UPDATE_AT,
             _DRAFT_DESCRIPTION,
         )
         assert draft.number == _DRAFT_NUMBER
@@ -161,7 +161,7 @@ class TestDraft:
         assert draft.description == _DRAFT_DESCRIPTION
         assert draft.parent_commit_id == _DRAFT_PARENT_COMMIT_ID
         assert draft.author == _DRAFT_AUTHOR
-        assert draft.updated_at == _DRAFT_UPDATED_AT
+        assert draft.update_at == _DRAFT_UPDATE_AT
 
     def test_loads(self):
         draft = Draft.loads(_DRAFT_DATA)
@@ -171,7 +171,7 @@ class TestDraft:
         assert draft.status == _DRAFT_DATA["status"]
         assert draft.parent_commit_id == _DRAFT_DATA["parentCommitId"]
         assert draft.author == User.loads(_DRAFT_DATA["author"])
-        assert draft.updated_at == _DRAFT_DATA["updatedAt"]
+        assert draft.update_at == _DRAFT_DATA["updateAt"]
 
     def test_dumps(self):
         draft = Draft(
@@ -181,6 +181,6 @@ class TestDraft:
             _DRAFT_STATUS,
             _DRAFT_PARENT_COMMIT_ID,
             _DRAFT_AUTHOR,
-            _DRAFT_UPDATED_AT,
+            _DRAFT_UPDATE_AT,
         )
         assert draft.dumps() == _DRAFT_DATA

--- a/tensorbay/conftest.py
+++ b/tensorbay/conftest.py
@@ -238,7 +238,7 @@ def mock_list_drafts(mocker, branch_name):
             "status": "OPEN",
             "parentCommitId": "4c564ea07f4e47679ec8c63d238bb3a1",
             "author": {"name": "draft author", "date": 1636967807},
-            "updatedAt": 1636967807,
+            "updateAt": 1636967807,
             "description": "first draft of test_draft",
         },
         {
@@ -248,7 +248,7 @@ def mock_list_drafts(mocker, branch_name):
             "status": "CLOSED",
             "parentCommitId": "4c564ea07f4e47679ec8c63d238bb3a1",
             "author": {"name": "draft author", "date": 1636967807},
-            "updatedAt": 1636967807,
+            "updateAt": 1636967807,
             "description": "",
         },
     ]


### PR DESCRIPTION
"updatedAt" -> "updateAt", "updated_at" -> "update_at"