### PR TITLE
refactor(opendataset): add typehint for the result of xmltodict.parse()

### DIFF
--- a/tensorbay/opendataset/AnimalPose/loader.py
+++ b/tensorbay/opendataset/AnimalPose/loader.py
@@ -8,7 +8,7 @@
 
 import json
 import os
-from typing import Iterable, Iterator, List, Tuple
+from typing import Any, Iterable, Iterator, List, Tuple
 
 from tensorbay.dataset import Data, Dataset
 from tensorbay.exception import ModuleImportError
@@ -115,7 +115,7 @@ def _get_data_part1(root_path: str, aniamls: Iterable[str]) -> Iterator[Data]:
             ):
 
                 with open(annotation_path, encoding="utf-8") as fp:
-                    labels = xmltodict.parse(fp.read())
+                    labels: Any = xmltodict.parse(fp.read())
 
                 box2d = labels["annotation"]["visible_bounds"]
                 data.label.box2d = [
@@ -158,7 +158,7 @@ def _get_data_part2(root_path: str, aniamls: Iterable[str]) -> Iterator[Data]:
             )
 
             with open(annotation_path, encoding="utf-8") as fp:
-                labels = xmltodict.parse(fp.read())
+                labels: Any = xmltodict.parse(fp.read())
 
             box2d = labels["annotation"]["visible_bounds"]
             data.label.box2d = [

--- a/tensorbay/opendataset/HardHatWorkers/loader.py
+++ b/tensorbay/opendataset/HardHatWorkers/loader.py
@@ -7,7 +7,7 @@
 """Dataloader of HardHatWorker dataset."""
 
 import os
-from typing import List
+from typing import Any, List
 
 from tensorbay.dataset import Data, Dataset
 from tensorbay.label import LabeledBox2D
@@ -60,7 +60,9 @@ def HardHatWorkers(path: str) -> Dataset:
 
 def _load_labels(label_file: str) -> List[LabeledBox2D]:
     with open(label_file, "r", encoding="utf-8") as fp:
-        objects = xmltodict.parse(fp.read())["annotation"]["object"]
+        labels: Any = xmltodict.parse(fp.read())
+
+    objects = labels["annotation"]["object"]
     box2ds = []
     if not isinstance(objects, list):
         objects = [objects]

--- a/tensorbay/opendataset/OxfordIIITPet/loader.py
+++ b/tensorbay/opendataset/OxfordIIITPet/loader.py
@@ -7,7 +7,7 @@
 """Dataloader of OxfordIIITPet dataset."""
 
 import os
-from typing import List
+from typing import Any, List
 
 from tensorbay.dataset import Data, Dataset
 from tensorbay.label import Classification, LabeledBox2D, SemanticMask
@@ -80,7 +80,9 @@ def OxfordIIITPet(path: str) -> Dataset:
 
 def _get_box_label(file_path: str) -> List[LabeledBox2D]:
     with open(file_path, "r", encoding="utf-8") as fp:
-        objects = xmltodict.parse(fp.read())["annotation"]["object"]
+        labels: Any = xmltodict.parse(fp.read())
+
+    objects = labels["annotation"]["object"]
     if not isinstance(objects, list):
         objects = [objects]
     box2d = []

--- a/tensorbay/opendataset/VOC2012ActionClassification/loader.py
+++ b/tensorbay/opendataset/VOC2012ActionClassification/loader.py
@@ -7,6 +7,7 @@
 """Dataloader of VOC2012ActionClassification dataset."""
 
 import os
+from typing import Any
 
 from tensorbay.dataset import Data, Dataset
 from tensorbay.exception import ModuleImportError
@@ -69,7 +70,9 @@ def _get_data(filename: str, image_path: str, annotation_path: str) -> Data:
     data = Data(os.path.join(image_path, f"{filename}.jpg"))
     box2d = []
     with open(os.path.join(annotation_path, f"{filename}.xml"), "r", encoding="utf-8") as fp:
-        objects = xmltodict.parse(fp.read())["annotation"]["object"]
+        labels: Any = xmltodict.parse(fp.read())
+
+    objects = labels["annotation"]["object"]
     if not isinstance(objects, list):
         objects = [objects]
     for item in objects:

--- a/tensorbay/opendataset/VOC2012Detection/loader.py
+++ b/tensorbay/opendataset/VOC2012Detection/loader.py
@@ -7,6 +7,7 @@
 """Dataloader of VOC2012Detection dataset."""
 
 import os
+from typing import Any
 
 from tensorbay.dataset import Data, Dataset
 from tensorbay.label import LabeledBox2D
@@ -79,7 +80,9 @@ def _get_data(filename: str, image_path: str, annotation_path: str) -> Data:
     data = Data(os.path.join(image_path, f"{filename}.jpg"))
     box2d = []
     with open(os.path.join(annotation_path, f"{filename}.xml"), "r", encoding="utf-8") as fp:
-        objects = xmltodict.parse(fp.read())["annotation"]["object"]
+        labels: Any = xmltodict.parse(fp.read())
+
+    objects = labels["annotation"]["object"]
     if not isinstance(objects, list):
         objects = [objects]
     for obj in objects:


### PR DESCRIPTION
Add `Any` typehint for the result of xmltodict.parse() to avoid the
Pyright error.