### PR TITLE
fix(geometry): fix the ValueError when init point list with numpy array

### DIFF
--- a/tensorbay/geometry/point_list.py
+++ b/tensorbay/geometry/point_list.py
@@ -32,7 +32,7 @@ class PointList2D(UserMutableSequence[_T]):
         self,
         points: Optional[Iterable[Iterable[float]]] = None,
     ) -> None:
-        self._data = [self._ElementType(*point) for point in points] if points else []
+        self._data = [self._ElementType(*point) for point in points] if points is not None else []
 
     def _loads(self, contents: Sequence[Mapping[str, float]]) -> None:
         self._data = []
@@ -114,7 +114,9 @@ class MultiPointList2D(UserMutableSequence[_L]):
 
     def __init__(self, point_lists: Optional[Iterable[Iterable[Iterable[float]]]] = None) -> None:
         self._data = (
-            [self._ElementType(point_list) for point_list in point_lists] if point_lists else []
+            [self._ElementType(point_list) for point_list in point_lists]
+            if point_lists is not None
+            else []
         )
 
     def _loads(self, contents: Sequence[Sequence[Mapping[str, float]]]) -> None:

--- a/tensorbay/geometry/polygon.py
+++ b/tensorbay/geometry/polygon.py
@@ -168,8 +168,8 @@ class RLE(UserMutableSequence[int]):
 
     _data: List[int]
 
-    def __init__(self, rle: Optional[Iterable[int]]):
-        self._data = list(rle) if rle else []
+    def __init__(self, rle: Optional[Iterable[int]] = None):
+        self._data = list(rle) if rle is not None else []
 
     def _dumps(self) -> List[int]:
         return self._data

--- a/tensorbay/geometry/tests/test_keypoint.py
+++ b/tensorbay/geometry/tests/test_keypoint.py
@@ -3,6 +3,8 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 
+import numpy as np
+
 from tensorbay.geometry import Box2D, Keypoint2D, Keypoints2D, Vector2D
 
 _DATA_KEYPOINT = {"x": 1.0, "y": 1.0, "v": 1}
@@ -34,7 +36,9 @@ class TestKeypoints2D:
     def test_init(self):
         sequence = [[1, 2], [2, 3]]
         assert Keypoints2D(None) == Keypoints2D([])
-        assert Keypoints2D(sequence) == Keypoints2D([Keypoint2D(1, 2), Keypoint2D(2, 3)])
+        result = Keypoints2D([Keypoint2D(1, 2), Keypoint2D(2, 3)])
+        assert Keypoints2D(sequence) == result
+        assert Keypoints2D(np.array(sequence)) == result
 
     def test_eq(self):
         keypoints_1 = Keypoints2D([[1, 2], [2, 3]])

--- a/tensorbay/geometry/tests/test_polygon.py
+++ b/tensorbay/geometry/tests/test_polygon.py
@@ -3,6 +3,8 @@
 # Copyright 2021 Graviti. Licensed under MIT License.
 #
 
+import numpy as np
+
 from tensorbay.geometry.box import Box2D
 from tensorbay.geometry.polygon import RLE, MultiPolygon, Polygon
 from tensorbay.geometry.vector import Vector2D
@@ -19,7 +21,9 @@ class TestPolygon:
     def test_init(self):
         sequence = [[1, 2], [2, 3], [2, 2]]
         assert Polygon(None) == Polygon([])
-        assert Polygon(sequence) == Polygon([Vector2D(1, 2), Vector2D(2, 3), Vector2D(2, 2)])
+        result = Polygon([Vector2D(1, 2), Vector2D(2, 3), Vector2D(2, 2)])
+        assert Polygon(sequence) == result
+        assert Polygon(np.array(sequence)) == result
 
     def test_eq(self):
         polygon_1 = Polygon([[1, 2], [2, 3], [2, 2]])
@@ -50,9 +54,9 @@ class TestMultiPolygon:
         assert MultiPolygon(None) == MultiPolygon([])
         polygon1 = Polygon([[1.0, 4.0], [2.0, 3.7], [7.0, 4.0]])
         polygon2 = Polygon([[5.0, 7.0], [6.0, 7.0], [9.0, 8.0]])
-        assert MultiPolygon(
-            [[[1.0, 4.0], [2.0, 3.7], [7.0, 4.0]], [[5.0, 7.0], [6.0, 7.0], [9.0, 8.0]]]
-        ) == MultiPolygon([polygon1, polygon2])
+        sequence = [[[1.0, 4.0], [2.0, 3.7], [7.0, 4.0]], [[5.0, 7.0], [6.0, 7.0], [9.0, 8.0]]]
+        assert MultiPolygon(sequence) == MultiPolygon([polygon1, polygon2])
+        assert MultiPolygon(np.array(sequence)) == MultiPolygon([polygon1, polygon2])
 
     def test_loads(self):
         multipolygon = MultiPolygon.loads(_DATA_MULTIPOLYGON)
@@ -70,7 +74,10 @@ class TestMultiPolygon:
 
 class TestRLE:
     def test_init(self):
-        assert RLE([272, 2, 4, 4, 2, 9])._data == [272, 2, 4, 4, 2, 9]
+        value = [272, 2, 4, 4, 2, 9]
+        assert RLE(value)._data == value
+        assert RLE(np.array(value))._data == value
+        assert RLE()._data == []
 
     def test_loads(self):
         rle = RLE.loads(_DATA_RLE)

--- a/tensorbay/geometry/tests/test_polyline.py
+++ b/tensorbay/geometry/tests/test_polyline.py
@@ -5,6 +5,8 @@
 
 from math import isclose
 
+import numpy as np
+
 from tensorbay.geometry import Box2D, MultiPolyline2D, Polyline2D, Vector2D
 
 _POLYLINE_SEQUENCE_1 = [[1, 1], [2, 2], [4, 4], [5, 5]]
@@ -65,7 +67,9 @@ class TestPolyline2D:
     def test_init(self):
         sequence = [[1, 1], [1, 2], [2, 2]]
         assert Polyline2D() == Polyline2D([])
-        assert Polyline2D(sequence) == Polyline2D([Vector2D(1, 1), Vector2D(1, 2), Vector2D(2, 2)])
+        result = Polyline2D([Vector2D(1, 1), Vector2D(1, 2), Vector2D(2, 2)])
+        assert Polyline2D(sequence) == result
+        assert Polyline2D(np.array(sequence)) == result
 
     def test_eq(self):
         polyline_1 = Polyline2D([[1, 2], [2, 3], [2, 2]])
@@ -118,12 +122,15 @@ class TestPolyline2D:
 class TestMultiPolyline2D:
     def test_init(self):
         assert MultiPolyline2D() == MultiPolyline2D([])
-        assert MultiPolyline2D(_MULTI_POLYLINE_SEQUENCE) == MultiPolyline2D(
+
+        result = MultiPolyline2D(
             [
                 [Vector2D(1, 1), Vector2D(2, 2), Vector2D(4, 4), Vector2D(5, 5)],
                 [Vector2D(2, 1), Vector2D(4, 3), Vector2D(6, 5)],
             ]
         )
+        assert MultiPolyline2D(_MULTI_POLYLINE_SEQUENCE) == result
+        assert MultiPolyline2D(np.array(_MULTI_POLYLINE_SEQUENCE)) == result
 
     def test_loads(self):
         assert MultiPolyline2D.loads(_MULTI_POLYLINE_CONTENT) == _MULTI_POLYLINE


### PR DESCRIPTION
When init pointlist related classes with numpy array, ValueError will be
raised:
```
ValueError: The truth value of an array with more than one element is
ambiguous. Use a.any() or a.all()
```