### PR TITLE
style(utility): add type hint and remove pylint comment in "repr._repr1"

### DIFF
--- a/tensorbay/utility/repr.py
+++ b/tensorbay/utility/repr.py
@@ -140,8 +140,7 @@ def _repr1(obj: Any, level: int, maxlevel: int, folding: bool) -> str:
         "repr" of the object.
 
     """
-    # pylint: disable=protected-access
-    class_ = type(obj)
+    class_: Type[Any] = type(obj)
     printer = _PRINTERS.get(getattr(class_, "_repr_type", class_), None)
     return printer(obj, level, maxlevel, folding) if printer else repr(obj)
 


### PR DESCRIPTION
1. add type hint to variable "class_" to remove the pyright warning
2. remove useless pylint disable "protected-access"